### PR TITLE
🔒 [security fix description] Replace weak MD5 hashing with SHA-256 for LLM context cache keys

### DIFF
--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -66,7 +66,7 @@ class TTLCache:
             "kwargs": kwargs,
         }
         cache_str = json.dumps(cache_data, sort_keys=True, default=str)
-        return hashlib.md5(cache_str.encode()).hexdigest()
+        return hashlib.sha256(cache_str.encode()).hexdigest()
 
     def _is_expired(self, expiry_time: float) -> bool:
         """Check if an entry has expired.
@@ -318,7 +318,7 @@ class CacheManager:
             Cache key string
         """
         # Use hash of context to keep key size manageable
-        context_hash = hashlib.md5(context.encode()).hexdigest()
+        context_hash = hashlib.sha256(context.encode()).hexdigest()
 
         return self.llm_cache._generate_key(
             "llm",


### PR DESCRIPTION
The vulnerability fixed is the use of the MD5 hashing algorithm for generating cache keys in `src/utils/cache.py`. MD5 is cryptographically weak and prone to collisions. Its use in cache keys could lead to the cache returning incorrect or potentially sensitive information from a different query due to a hash collision.

The fix involved replacing all occurrences of `hashlib.md5` with `hashlib.sha256` in the `src/utils/cache.py` file, specifically in the `TTLCache._generate_key` method and the `CacheManager.get_llm_cache_key` method. This change ensures that cache keys are generated using a cryptographically stronger hash, significantly reducing the risk of collisions and improving the overall security of the system.

Verified the fix by ensuring the generated cache keys are now 64 characters long (SHA-256) instead of 32 characters (MD5) using a mock script and code analysis. Existing functionality is preserved, although existing cache entries will be invalidated upon the first run after the update.

---
*PR created automatically by Jules for task [12429962214967269767](https://jules.google.com/task/12429962214967269767) started by @prateekmulye*