### PR TITLE
🎨 Palette: Disable clear conversation button when empty

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-15 - Streamlit duplicate buttons\n**Learning:** When automating Streamlit UI interactions via Playwright, component locators (like `page.locator('button')`) may resolve to multiple duplicate DOM elements due to Streamlit's internal rendering. Always append `.first` or use `.nth()` alongside text filters to prevent strict mode violations during `.click()` actions.\n**Action:** Always append `.first` or use `.nth()` alongside text filters.
+
+## 2024-05-15 - Conditionally disable interactive elements
+**Learning:** A preferred micro-UX pattern in Streamlit applications is conditionally disabling interactive elements (like buttons) when their corresponding action is invalid based on the current system state, such as checking `len(st.session_state.messages) == 0`.
+**Action:** Always provide accurate visual feedback on system state and prevent invalid user actions by conditionally disabling UI elements and providing contextual help messages.

--- a/src/prompts/rag_prompts.py
+++ b/src/prompts/rag_prompts.py
@@ -145,13 +145,15 @@ CONVERSATIONAL_RAG_PROMPT = ChatPromptTemplate.from_messages(
     [
         SystemMessage(content="You are ChatFormula1, an expert Formula 1 analyst."),
         MessagesPlaceholder(variable_name="chat_history", optional=True),
-        HumanMessagePromptTemplate.from_template("""**Retrieved Context:**
+        HumanMessagePromptTemplate.from_template(
+            """**Retrieved Context:**
 {context}
 
 **Current Question:**
 {query}
 
-Use the context above and our conversation history to answer the question."""),
+Use the context above and our conversation history to answer the question."""
+        ),
     ]
 )
 

--- a/src/prompts/rag_prompts.py
+++ b/src/prompts/rag_prompts.py
@@ -145,15 +145,13 @@ CONVERSATIONAL_RAG_PROMPT = ChatPromptTemplate.from_messages(
     [
         SystemMessage(content="You are ChatFormula1, an expert Formula 1 analyst."),
         MessagesPlaceholder(variable_name="chat_history", optional=True),
-        HumanMessagePromptTemplate.from_template(
-            """**Retrieved Context:**
+        HumanMessagePromptTemplate.from_template("""**Retrieved Context:**
 {context}
 
 **Current Question:**
 {query}
 
-Use the context above and our conversation history to answer the question."""
-        ),
+Use the context above and our conversation history to answer the question."""),
     ]
 )
 

--- a/src/prompts/system_prompts.py
+++ b/src/prompts/system_prompts.py
@@ -245,9 +245,7 @@ Keep responses brief but informative. Cite specific data when relevant. Stay foc
 DETAILED_SYSTEM_PROMPT = create_system_prompt(include_guardrails=True)
 
 PREDICTION_SYSTEM_PROMPT = ChatPromptTemplate.from_messages(
-    [
-        SystemMessage(
-            content=f"""{F1_EXPERT_SYSTEM_PROMPT}
+    [SystemMessage(content=f"""{F1_EXPERT_SYSTEM_PROMPT}
 
 **Prediction Mode:**
 When making predictions:
@@ -260,7 +258,5 @@ When making predictions:
 
 Always explain your reasoning with supporting data points.
 {OFF_TOPIC_GUARDRAIL_PROMPT}
-"""
-        )
-    ]
+""")]
 )

--- a/src/prompts/system_prompts.py
+++ b/src/prompts/system_prompts.py
@@ -245,7 +245,9 @@ Keep responses brief but informative. Cite specific data when relevant. Stay foc
 DETAILED_SYSTEM_PROMPT = create_system_prompt(include_guardrails=True)
 
 PREDICTION_SYSTEM_PROMPT = ChatPromptTemplate.from_messages(
-    [SystemMessage(content=f"""{F1_EXPERT_SYSTEM_PROMPT}
+    [
+        SystemMessage(
+            content=f"""{F1_EXPERT_SYSTEM_PROMPT}
 
 **Prediction Mode:**
 When making predictions:
@@ -258,5 +260,7 @@ When making predictions:
 
 Always explain your reasoning with supporting data points.
 {OFF_TOPIC_GUARDRAIL_PROMPT}
-""")]
+"""
+        )
+    ]
 )

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -10,11 +10,11 @@ This module implements the main Streamlit application with:
 import asyncio
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 import streamlit as st
 import structlog
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from src.agent.graph import F1AgentGraph
 from src.agent.state import create_initial_state
@@ -103,7 +103,7 @@ def initialize_session_state() -> None:
         st.session_state.last_error = None
 
 
-def initialize_agent() -> F1AgentGraph | None:
+def initialize_agent() -> Optional[F1AgentGraph]:
     """Initialize the agent graph and dependencies.
 
     Returns:
@@ -214,11 +214,7 @@ def render_sidebar() -> None:
             "🗑️ Clear Conversation",
             use_container_width=True,
             disabled=not has_messages,
-            help=(
-                "Delete all messages in the current conversation"
-                if has_messages
-                else "No messages to clear"
-            ),
+            help="Delete all messages in the current conversation" if has_messages else "No messages to clear",
         ):
             st.session_state.messages = []
             st.session_state.agent_state = None
@@ -258,8 +254,7 @@ def render_sidebar() -> None:
 
         # Help section
         with st.expander("❓ Help & Tips"):
-            st.markdown(
-                """
+            st.markdown("""
             **What can I ask?**
             - Current F1 standings and results
             - Historical statistics and records
@@ -272,13 +267,11 @@ def render_sidebar() -> None:
             - Mention years, drivers, or races for better context
             - Ask follow-up questions naturally
             - Use the feedback buttons to help improve responses
-            """
-            )
+            """)
 
         # About section
         with st.expander("ℹ️ About"):
-            st.markdown(
-                """
+            st.markdown("""
             **ChatFormula1** is an AI-powered Formula 1 expert assistant
             that combines:
             - Real-time F1 data and news
@@ -295,8 +288,7 @@ def render_sidebar() -> None:
             **Connect:**
             - 🔗 LinkedIn: [linkedin.com/in/prateekmulye](https://www.linkedin.com/in/prateekmulye/)
             - 💻 GitHub: [github.com/prateekmulye](https://github.com/prateekmulye)
-            """
-            )
+            """)
 
 
 def render_header() -> None:
@@ -349,7 +341,7 @@ def render_header() -> None:
             st.rerun()
 
 
-def render_chat_interface(agent: F1AgentGraph | None) -> None:
+def render_chat_interface(agent: Optional[F1AgentGraph]) -> None:
     """Render the main chat interface with message history and input.
 
     This function implements the ChatGPT/Anthropic UX pattern where:

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -10,11 +10,11 @@ This module implements the main Streamlit application with:
 import asyncio
 import uuid
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 import streamlit as st
 import structlog
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import HumanMessage, SystemMessage
 
 from src.agent.graph import F1AgentGraph
 from src.agent.state import create_initial_state
@@ -103,7 +103,7 @@ def initialize_session_state() -> None:
         st.session_state.last_error = None
 
 
-def initialize_agent() -> Optional[F1AgentGraph]:
+def initialize_agent() -> F1AgentGraph | None:
     """Initialize the agent graph and dependencies.
 
     Returns:
@@ -209,7 +209,17 @@ def render_sidebar() -> None:
         st.metric("Messages", msg_count)
 
         # Clear conversation button
-        if st.button("🗑️ Clear Conversation", use_container_width=True):
+        has_messages = len(st.session_state.messages) > 0
+        if st.button(
+            "🗑️ Clear Conversation",
+            use_container_width=True,
+            disabled=not has_messages,
+            help=(
+                "Delete all messages in the current conversation"
+                if has_messages
+                else "No messages to clear"
+            ),
+        ):
             st.session_state.messages = []
             st.session_state.agent_state = None
             st.session_state.feedback = {}
@@ -248,41 +258,45 @@ def render_sidebar() -> None:
 
         # Help section
         with st.expander("❓ Help & Tips"):
-            st.markdown("""
+            st.markdown(
+                """
             **What can I ask?**
             - Current F1 standings and results
             - Historical statistics and records
             - Race predictions and analysis
             - Technical regulations and rules
             - Driver and team information
-            
+
             **Tips:**
             - Be specific with your questions
             - Mention years, drivers, or races for better context
             - Ask follow-up questions naturally
             - Use the feedback buttons to help improve responses
-            """)
+            """
+            )
 
         # About section
         with st.expander("ℹ️ About"):
-            st.markdown("""
+            st.markdown(
+                """
             **ChatFormula1** is an AI-powered Formula 1 expert assistant
             that combines:
             - Real-time F1 data and news
             - Historical F1 knowledge base
             - Advanced language models
             - RAG (Retrieval-Augmented Generation)
-            
+
             Built with LangChain, LangGraph, Pinecone, and Streamlit.
-            
+
             ---
-            
+
             **Created by:** Prateek Mulye
-            
+
             **Connect:**
             - 🔗 LinkedIn: [linkedin.com/in/prateekmulye](https://www.linkedin.com/in/prateekmulye/)
             - 💻 GitHub: [github.com/prateekmulye](https://github.com/prateekmulye)
-            """)
+            """
+            )
 
 
 def render_header() -> None:
@@ -335,7 +349,7 @@ def render_header() -> None:
             st.rerun()
 
 
-def render_chat_interface(agent: Optional[F1AgentGraph]) -> None:
+def render_chat_interface(agent: F1AgentGraph | None) -> None:
     """Render the main chat interface with message history and input.
 
     This function implements the ChatGPT/Anthropic UX pattern where:

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -214,7 +214,11 @@ def render_sidebar() -> None:
             "🗑️ Clear Conversation",
             use_container_width=True,
             disabled=not has_messages,
-            help="Delete all messages in the current conversation" if has_messages else "No messages to clear",
+            help=(
+                "Delete all messages in the current conversation"
+                if has_messages
+                else "No messages to clear"
+            ),
         ):
             st.session_state.messages = []
             st.session_state.agent_state = None
@@ -254,7 +258,8 @@ def render_sidebar() -> None:
 
         # Help section
         with st.expander("❓ Help & Tips"):
-            st.markdown("""
+            st.markdown(
+                """
             **What can I ask?**
             - Current F1 standings and results
             - Historical statistics and records
@@ -267,11 +272,13 @@ def render_sidebar() -> None:
             - Mention years, drivers, or races for better context
             - Ask follow-up questions naturally
             - Use the feedback buttons to help improve responses
-            """)
+            """
+            )
 
         # About section
         with st.expander("ℹ️ About"):
-            st.markdown("""
+            st.markdown(
+                """
             **ChatFormula1** is an AI-powered Formula 1 expert assistant
             that combines:
             - Real-time F1 data and news
@@ -288,7 +295,8 @@ def render_sidebar() -> None:
             **Connect:**
             - 🔗 LinkedIn: [linkedin.com/in/prateekmulye](https://www.linkedin.com/in/prateekmulye/)
             - 💻 GitHub: [github.com/prateekmulye](https://github.com/prateekmulye)
-            """)
+            """
+            )
 
 
 def render_header() -> None:

--- a/src/ui/components.py
+++ b/src/ui/components.py
@@ -9,7 +9,7 @@ This module provides components for:
 """
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 import streamlit as st
 import structlog
@@ -760,8 +760,8 @@ def apply_f1_theme() -> None:
 def render_message(
     role: str,
     content: str,
-    metadata: dict[str, Any] | None = None,
-    message_id: str | None = None,
+    metadata: Optional[dict[str, Any]] = None,
+    message_id: Optional[str] = None,
 ) -> None:
     """Render a chat message with role-based styling.
 
@@ -782,7 +782,7 @@ def render_message(
 
 def render_message_metadata(
     metadata: dict[str, Any],
-    message_id: str | None = None,
+    message_id: Optional[str] = None,
 ) -> None:
     """Render metadata section for assistant messages.
 
@@ -897,6 +897,7 @@ def render_feedback_buttons(message_id: str) -> None:
     Requirements: 4.6, 5.5
     """
     # Check if feedback already given
+    feedback_key = f"feedback_{message_id}"
     current_feedback = st.session_state.feedback.get(message_id)
 
     col1, col2 = st.columns(2)
@@ -1277,31 +1278,27 @@ def render_about_modal() -> None:
     try:
 
         @st.dialog("About ChatFormula1")
-        def show_about() -> None:
+        def show_about():
             """Inner function to display about modal content."""
             # Project title with F1 emoji
             st.markdown("## 🏎️ ChatFormula1")
 
             # Project description
-            st.markdown(
-                """
+            st.markdown("""
             An AI-powered Formula 1 expert assistant that combines real-time
             data, historical knowledge, and advanced language models to provide
             comprehensive answers about Formula 1 racing.
-            """
-            )
+            """)
 
             # Features list
             st.markdown("### ✨ Features")
-            st.markdown(
-                """
+            st.markdown("""
             - **Real-time F1 Data**: Current standings, race results, and live updates
             - **Historical Statistics**: Comprehensive F1 records and historical data
             - **Data-driven Predictions**: AI-powered race and championship predictions
             - **RAG-powered Knowledge**: Retrieval-Augmented Generation for accurate responses
             - **Natural Conversations**: Chat naturally about any F1 topic
-            """
-            )
+            """)
 
             st.divider()
 
@@ -1329,15 +1326,13 @@ def render_about_modal() -> None:
 
             # Technology stack
             st.markdown("### 🛠️ Built With")
-            st.markdown(
-                """
+            st.markdown("""
             - **LangChain & LangGraph**: Agent orchestration and workflow
             - **OpenAI GPT-4**: Language model for natural conversations
             - **Pinecone**: Vector database for knowledge retrieval
             - **Tavily**: Real-time web search integration
             - **Streamlit**: Interactive web interface
-            """
-            )
+            """)
 
             # Footer with version info
             st.markdown("---")
@@ -1356,8 +1351,7 @@ def render_about_modal() -> None:
         # Display fallback content
         st.error("⚠️ Unable to display About modal. Here's the information:")
 
-        st.markdown(
-            """
+        st.markdown("""
         ### 🏎️ ChatFormula1
 
         An AI-powered Formula 1 expert assistant combining real-time data,
@@ -1370,8 +1364,7 @@ def render_about_modal() -> None:
         - GitHub: https://github.com/prateekmulye
 
         **Built with:** LangChain, LangGraph, OpenAI, Pinecone, Tavily, and Streamlit
-        """
-        )
+        """)
 
 
 def render_welcome_message() -> None:
@@ -1380,8 +1373,7 @@ def render_welcome_message() -> None:
     DEPRECATED: Use render_welcome_screen() instead for the new UI design.
     This function is kept for backward compatibility.
     """
-    st.markdown(
-        """
+    st.markdown("""
     ### Welcome to ChatFormula1! 🏎️
 
     I'm your AI-powered Formula 1 expert assistant. I can help you with:
@@ -1401,8 +1393,7 @@ def render_welcome_message() -> None:
     - "What are the current technical regulations?"
 
     Just type your question below to get started! 🚀
-    """
-    )
+    """)
 
 
 def render_input_validation_error(error_type: str) -> None:
@@ -1534,11 +1525,7 @@ def render_settings_panel() -> None:
                 "🗑️ Clear Conversation",
                 use_container_width=True,
                 key="settings_clear",
-                help=(
-                    "Delete all messages in the current conversation"
-                    if has_messages
-                    else "No messages to clear"
-                ),
+                help="Delete all messages in the current conversation" if has_messages else "No messages to clear",
                 disabled=not has_messages,
             ):
                 st.session_state.messages = []

--- a/src/ui/components.py
+++ b/src/ui/components.py
@@ -1284,21 +1284,25 @@ def render_about_modal() -> None:
             st.markdown("## 🏎️ ChatFormula1")
 
             # Project description
-            st.markdown("""
+            st.markdown(
+                """
             An AI-powered Formula 1 expert assistant that combines real-time
             data, historical knowledge, and advanced language models to provide
             comprehensive answers about Formula 1 racing.
-            """)
+            """
+            )
 
             # Features list
             st.markdown("### ✨ Features")
-            st.markdown("""
+            st.markdown(
+                """
             - **Real-time F1 Data**: Current standings, race results, and live updates
             - **Historical Statistics**: Comprehensive F1 records and historical data
             - **Data-driven Predictions**: AI-powered race and championship predictions
             - **RAG-powered Knowledge**: Retrieval-Augmented Generation for accurate responses
             - **Natural Conversations**: Chat naturally about any F1 topic
-            """)
+            """
+            )
 
             st.divider()
 
@@ -1326,13 +1330,15 @@ def render_about_modal() -> None:
 
             # Technology stack
             st.markdown("### 🛠️ Built With")
-            st.markdown("""
+            st.markdown(
+                """
             - **LangChain & LangGraph**: Agent orchestration and workflow
             - **OpenAI GPT-4**: Language model for natural conversations
             - **Pinecone**: Vector database for knowledge retrieval
             - **Tavily**: Real-time web search integration
             - **Streamlit**: Interactive web interface
-            """)
+            """
+            )
 
             # Footer with version info
             st.markdown("---")
@@ -1351,7 +1357,8 @@ def render_about_modal() -> None:
         # Display fallback content
         st.error("⚠️ Unable to display About modal. Here's the information:")
 
-        st.markdown("""
+        st.markdown(
+            """
         ### 🏎️ ChatFormula1
 
         An AI-powered Formula 1 expert assistant combining real-time data,
@@ -1364,7 +1371,8 @@ def render_about_modal() -> None:
         - GitHub: https://github.com/prateekmulye
 
         **Built with:** LangChain, LangGraph, OpenAI, Pinecone, Tavily, and Streamlit
-        """)
+        """
+        )
 
 
 def render_welcome_message() -> None:
@@ -1373,7 +1381,8 @@ def render_welcome_message() -> None:
     DEPRECATED: Use render_welcome_screen() instead for the new UI design.
     This function is kept for backward compatibility.
     """
-    st.markdown("""
+    st.markdown(
+        """
     ### Welcome to ChatFormula1! 🏎️
 
     I'm your AI-powered Formula 1 expert assistant. I can help you with:
@@ -1393,7 +1402,8 @@ def render_welcome_message() -> None:
     - "What are the current technical regulations?"
 
     Just type your question below to get started! 🚀
-    """)
+    """
+    )
 
 
 def render_input_validation_error(error_type: str) -> None:
@@ -1525,7 +1535,11 @@ def render_settings_panel() -> None:
                 "🗑️ Clear Conversation",
                 use_container_width=True,
                 key="settings_clear",
-                help="Delete all messages in the current conversation" if has_messages else "No messages to clear",
+                help=(
+                    "Delete all messages in the current conversation"
+                    if has_messages
+                    else "No messages to clear"
+                ),
                 disabled=not has_messages,
             ):
                 st.session_state.messages = []

--- a/src/ui/components.py
+++ b/src/ui/components.py
@@ -9,7 +9,7 @@ This module provides components for:
 """
 
 from datetime import datetime
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 import streamlit as st
 import structlog
@@ -137,7 +137,7 @@ def apply_f1_theme() -> None:
         margin-top: {theme.spacing_sm};
         line-height: 1.4;
     }}
-    
+
     /* Welcome description styling */
     .welcome-description {{
         text-align: center;
@@ -179,7 +179,7 @@ def apply_f1_theme() -> None:
         transform: scale(0.98);
         transition: all {theme.transition_fast};
     }}
-    
+
     /* Recommendation prompt specific styling with hover effects */
     .stButton > button[kind="secondary"] {{
         min-height: 80px;
@@ -269,29 +269,29 @@ def apply_f1_theme() -> None:
         outline: none;
         transition: all {theme.transition_fast};
     }}
-    
+
     /* Persistent search bar on welcome screen - ChatGPT/Anthropic UX pattern */
     .stChatInput {{
         margin-top: {theme.spacing_xl};
         margin-bottom: {theme.spacing_md};
         animation: fadeIn 0.6s ease-in;
     }}
-    
+
     .stChatInput > div {{
         border-radius: {theme.radius_md};
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
         transition: box-shadow {theme.transition_normal};
     }}
-    
+
     .stChatInput > div:hover {{
         box-shadow: 0 4px 12px rgba(225, 6, 0, 0.2);
         transition: box-shadow {theme.transition_normal};
     }}
-    
+
     .stChatInput > div > div {{
         border-radius: {theme.radius_md};
     }}
-    
+
     /* Welcome screen specific spacing for search bar */
     .stChatInput + div {{
         margin-top: {theme.spacing_lg};
@@ -760,8 +760,8 @@ def apply_f1_theme() -> None:
 def render_message(
     role: str,
     content: str,
-    metadata: Optional[dict[str, Any]] = None,
-    message_id: Optional[str] = None,
+    metadata: dict[str, Any] | None = None,
+    message_id: str | None = None,
 ) -> None:
     """Render a chat message with role-based styling.
 
@@ -782,7 +782,7 @@ def render_message(
 
 def render_message_metadata(
     metadata: dict[str, Any],
-    message_id: Optional[str] = None,
+    message_id: str | None = None,
 ) -> None:
     """Render metadata section for assistant messages.
 
@@ -897,7 +897,6 @@ def render_feedback_buttons(message_id: str) -> None:
     Requirements: 4.6, 5.5
     """
     # Check if feedback already given
-    feedback_key = f"feedback_{message_id}"
     current_feedback = st.session_state.feedback.get(message_id)
 
     col1, col2 = st.columns(2)
@@ -1244,7 +1243,7 @@ def render_welcome_screen() -> None:
     st.markdown(
         """
         <div style='text-align: center; margin: 1.5rem auto; max-width: 600px; color: #888888; font-size: 1.1rem; line-height: 1.6;'>
-            Get instant answers about F1 standings, race results, and predictions powered by advanced AI. 
+            Get instant answers about F1 standings, race results, and predictions powered by advanced AI.
             Access real-time data and historical statistics to explore everything Formula 1.
         </div>
         """,
@@ -1278,27 +1277,31 @@ def render_about_modal() -> None:
     try:
 
         @st.dialog("About ChatFormula1")
-        def show_about():
+        def show_about() -> None:
             """Inner function to display about modal content."""
             # Project title with F1 emoji
             st.markdown("## 🏎️ ChatFormula1")
 
             # Project description
-            st.markdown("""
-            An AI-powered Formula 1 expert assistant that combines real-time 
-            data, historical knowledge, and advanced language models to provide 
+            st.markdown(
+                """
+            An AI-powered Formula 1 expert assistant that combines real-time
+            data, historical knowledge, and advanced language models to provide
             comprehensive answers about Formula 1 racing.
-            """)
+            """
+            )
 
             # Features list
             st.markdown("### ✨ Features")
-            st.markdown("""
+            st.markdown(
+                """
             - **Real-time F1 Data**: Current standings, race results, and live updates
             - **Historical Statistics**: Comprehensive F1 records and historical data
             - **Data-driven Predictions**: AI-powered race and championship predictions
             - **RAG-powered Knowledge**: Retrieval-Augmented Generation for accurate responses
             - **Natural Conversations**: Chat naturally about any F1 topic
-            """)
+            """
+            )
 
             st.divider()
 
@@ -1326,13 +1329,15 @@ def render_about_modal() -> None:
 
             # Technology stack
             st.markdown("### 🛠️ Built With")
-            st.markdown("""
+            st.markdown(
+                """
             - **LangChain & LangGraph**: Agent orchestration and workflow
             - **OpenAI GPT-4**: Language model for natural conversations
             - **Pinecone**: Vector database for knowledge retrieval
             - **Tavily**: Real-time web search integration
             - **Streamlit**: Interactive web interface
-            """)
+            """
+            )
 
             # Footer with version info
             st.markdown("---")
@@ -1351,20 +1356,22 @@ def render_about_modal() -> None:
         # Display fallback content
         st.error("⚠️ Unable to display About modal. Here's the information:")
 
-        st.markdown("""
+        st.markdown(
+            """
         ### 🏎️ ChatFormula1
-        
-        An AI-powered Formula 1 expert assistant combining real-time data, 
+
+        An AI-powered Formula 1 expert assistant combining real-time data,
         historical knowledge, and advanced language models.
-        
+
         **Created by:** Prateek Mulye
-        
+
         **Connect:**
         - LinkedIn: https://www.linkedin.com/in/prateekmulye/
         - GitHub: https://github.com/prateekmulye
-        
+
         **Built with:** LangChain, LangGraph, OpenAI, Pinecone, Tavily, and Streamlit
-        """)
+        """
+        )
 
 
 def render_welcome_message() -> None:
@@ -1373,27 +1380,29 @@ def render_welcome_message() -> None:
     DEPRECATED: Use render_welcome_screen() instead for the new UI design.
     This function is kept for backward compatibility.
     """
-    st.markdown("""
+    st.markdown(
+        """
     ### Welcome to ChatFormula1! 🏎️
-    
+
     I'm your AI-powered Formula 1 expert assistant. I can help you with:
-    
+
     - 📊 **Current Standings**: Latest driver and constructor standings
     - 🏁 **Race Results**: Recent and historical race outcomes
     - 📈 **Predictions**: Data-driven race and championship predictions
     - 📚 **History**: F1 statistics, records, and historical information
     - ⚙️ **Technical**: Regulations, car specifications, and technical details
     - 👤 **Drivers & Teams**: Information about drivers, teams, and personnel
-    
+
     **Try asking:**
     - "Who is leading the championship?"
     - "What happened in the last race?"
     - "Predict the winner of the next race"
     - "Tell me about Lewis Hamilton's career"
     - "What are the current technical regulations?"
-    
+
     Just type your question below to get started! 🚀
-    """)
+    """
+    )
 
 
 def render_input_validation_error(error_type: str) -> None:
@@ -1520,11 +1529,17 @@ def render_settings_panel() -> None:
         col1, col2 = st.columns(2)
 
         with col1:
+            has_messages = len(st.session_state.messages) > 0
             if st.button(
                 "🗑️ Clear Conversation",
                 use_container_width=True,
                 key="settings_clear",
-                help="Delete all messages in the current conversation",
+                help=(
+                    "Delete all messages in the current conversation"
+                    if has_messages
+                    else "No messages to clear"
+                ),
+                disabled=not has_messages,
             ):
                 st.session_state.messages = []
                 st.session_state.agent_state = None


### PR DESCRIPTION
💡 What: Conditionally disabled the "Clear Conversation" buttons in the sidebar and settings panel when there are no messages in the chat history. The button tooltip dynamically updates to indicate "No messages to clear" when disabled.

🎯 Why: To provide accurate visual feedback on the system state and prevent users from attempting invalid actions (clearing an already empty conversation). This follows preferred Streamlit micro-UX patterns.

📸 Before/After: Before, the button was always clickable and active even when the chat was empty. Now, it visually dims and cannot be clicked until a message exists in the session.

♿️ Accessibility: The dynamic tooltip text explains the disabled state to users, ensuring clarity on why the interaction is prevented.

---
*PR created automatically by Jules for task [8344327206324164056](https://jules.google.com/task/8344327206324164056) started by @prateekmulye*