### PR TITLE
⚡ Bolt: [performance improvement] throttle cache eviction on read path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-24 - Throttling Cache Eviction on Read Path
+**Learning:** O(N) cache eviction scans on read paths (like `.get()`) can destroy O(1) performance guarantees and cause severe bottlenecks under heavy load, especially as cache sizes grow.
+**Action:** Throttle eviction scans on read paths using a timestamp mechanism (e.g., minimum 60-second interval between scans) to maintain consistent O(1) read latency.

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -12,8 +12,7 @@ import hashlib
 import json
 import time
 from collections import OrderedDict
-from datetime import datetime, timedelta
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 import structlog
 
@@ -41,9 +40,10 @@ class TTLCache:
         """
         self.max_size = max_size
         self.default_ttl = default_ttl
-        self._cache: OrderedDict[str, Tuple[Any, float]] = OrderedDict()
+        self._cache: OrderedDict[str, tuple[Any, float]] = OrderedDict()
         self._hits = 0
         self._misses = 0
+        self._last_evict_time = 0.0  # Throttle eviction scans
 
         logger.info(
             "ttl_cache_initialized",
@@ -51,7 +51,7 @@ class TTLCache:
             default_ttl=default_ttl,
         )
 
-    def _generate_key(self, *args: Any, **kwargs: Any) -> str:
+    def _generate_key(self, *args: Any, **kwargs: Any) -> str:  # noqa: ANN401
         """Generate cache key from arguments.
 
         Args:
@@ -103,7 +103,7 @@ class TTLCache:
             key, _ = self._cache.popitem(last=False)
             logger.debug("lru_entry_evicted", key=key[:16])
 
-    def get(self, key: str) -> Optional[Any]:
+    def get(self, key: str) -> Any | None:  # noqa: ANN401
         """Get value from cache.
 
         Args:
@@ -112,9 +112,12 @@ class TTLCache:
         Returns:
             Cached value if found and not expired, None otherwise
         """
-        # Clean up expired entries periodically
-        if len(self._cache) > self.max_size * 0.9:
+        # Clean up expired entries periodically, but throttle to max once per minute
+        # to prevent O(N) scan from destroying O(1) read latency under heavy load
+        current_time = time.time()
+        if len(self._cache) > self.max_size * 0.9 and (current_time - self._last_evict_time > 60.0):
             self._evict_expired()
+            self._last_evict_time = current_time
 
         if key in self._cache:
             value, expiry = self._cache[key]
@@ -136,7 +139,7 @@ class TTLCache:
         logger.debug("cache_miss", key=key[:16])
         return None
 
-    def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+    def set(self, key: str, value: Any, ttl: int | None = None) -> None:  # noqa: ANN401
         """Set value in cache.
 
         Args:
@@ -190,7 +193,7 @@ class TTLCache:
         logger.info("cache_cleared", entries_cleared=count)
         return count
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get cache statistics.
 
         Returns:
@@ -257,7 +260,7 @@ class CacheManager:
         self,
         query: str,
         k: int,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: dict[str, Any] | None = None,
     ) -> str:
         """Generate cache key for vector search.
 
@@ -328,7 +331,7 @@ class CacheManager:
             temperature,
         )
 
-    def clear_all(self) -> Dict[str, int]:
+    def clear_all(self) -> dict[str, int]:
         """Clear all caches.
 
         Returns:
@@ -340,7 +343,7 @@ class CacheManager:
             "llm_cache": self.llm_cache.clear(),
         }
 
-    def get_all_stats(self) -> Dict[str, Dict[str, Any]]:
+    def get_all_stats(self) -> dict[str, dict[str, Any]]:
         """Get statistics for all caches.
 
         Returns:
@@ -354,7 +357,7 @@ class CacheManager:
 
 
 # Global cache manager instance
-_cache_manager: Optional[CacheManager] = None
+_cache_manager: CacheManager | None = None
 
 
 def get_cache_manager() -> CacheManager:
@@ -372,7 +375,7 @@ def get_cache_manager() -> CacheManager:
     return _cache_manager
 
 
-def clear_all_caches() -> Dict[str, int]:
+def clear_all_caches() -> dict[str, int]:
     """Clear all caches in the global cache manager.
 
     Returns:
@@ -382,7 +385,7 @@ def clear_all_caches() -> Dict[str, int]:
     return manager.clear_all()
 
 
-def get_cache_stats() -> Dict[str, Dict[str, Any]]:
+def get_cache_stats() -> dict[str, dict[str, Any]]:
     """Get statistics for all caches.
 
     Returns:

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -115,7 +115,9 @@ class TTLCache:
         # Clean up expired entries periodically, but throttle to max once per minute
         # to prevent O(N) scan from destroying O(1) read latency under heavy load
         current_time = time.time()
-        if len(self._cache) > self.max_size * 0.9 and (current_time - self._last_evict_time > 60.0):
+        if len(self._cache) > self.max_size * 0.9 and (
+            current_time - self._last_evict_time > 60.0
+        ):
             self._evict_expired()
             self._last_evict_time = current_time
 


### PR DESCRIPTION
💡 What: Throttled the O(N) `_evict_expired()` cache eviction scans triggered within the cache read path `get()`. It now executes at most once per minute instead of constantly blocking reads.
🎯 Why: O(N) cache eviction scans on read paths (like `.get()`) destroy O(1) performance guarantees and cause severe bottlenecks under heavy load, especially as cache sizes grow.
📊 Impact: Maintains consistent O(1) read latency under heavy load and large cache sizes.
🔬 Measurement: Verify cache read times during load test with concurrent cache access and large cache sizes.

---
*PR created automatically by Jules for task [9184741228090603838](https://jules.google.com/task/9184741228090603838) started by @prateekmulye*