### PR TITLE
⚡ Bolt: Throttle cache eviction to prevent O(N) degradation on read paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Throttle O(N) cache eviction scans on read paths
+**Learning:** In the `TTLCache` class, `_evict_expired()` performs an O(N) scan of the entire dictionary. When triggered automatically on read operations (`get()`) solely based on cache size (`len(self._cache) > self.max_size * 0.9`), a mostly-full cache can trigger this O(N) scan on *every single read*, destroying O(1) performance guarantees and causing severe latency spikes.
+**Action:** When implementing or reviewing cache structures that use O(N) cleanup mechanisms, always decouple them from the direct read path or aggressively throttle them (e.g., using a minimum time interval like 60 seconds) to ensure `get()` operations remain O(1) even under heavy load or full-cache conditions.

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -44,6 +44,7 @@ class TTLCache:
         self._cache: OrderedDict[str, Tuple[Any, float]] = OrderedDict()
         self._hits = 0
         self._misses = 0
+        self._last_eviction_time = 0.0
 
         logger.info(
             "ttl_cache_initialized",
@@ -85,6 +86,8 @@ class TTLCache:
         Returns:
             Number of entries evicted
         """
+        self._last_eviction_time = time.time()
+
         expired_keys = [
             key for key, (_, expiry) in self._cache.items() if self._is_expired(expiry)
         ]
@@ -112,8 +115,8 @@ class TTLCache:
         Returns:
             Cached value if found and not expired, None otherwise
         """
-        # Clean up expired entries periodically
-        if len(self._cache) > self.max_size * 0.9:
+        # Clean up expired entries periodically (throttled to max once per minute)
+        if len(self._cache) > self.max_size * 0.9 and time.time() - self._last_eviction_time > 60.0:
             self._evict_expired()
 
         if key in self._cache:


### PR DESCRIPTION
💡 What: Throttle O(N) expired entry scans in `TTLCache.get()` using a timestamp mechanism (`_last_eviction_time`) to run at most once every 60 seconds.
🎯 Why: Without throttling, reads (`.get()`) under heavy load with a nearly full cache trigger an O(N) scan of the entire dictionary, destroying O(1) read performance guarantees and blocking the main thread.
📊 Impact: Restores O(1) performance guarantees for cache hits under heavy load by ensuring expensive eviction sweeps run infrequently and decoupling them from request read paths as much as possible.
🔬 Measurement: Run load tests or monitor P99 latencies for cache reads under high concurrency and observe significant latency reductions.

---
*PR created automatically by Jules for task [9650355704888857576](https://jules.google.com/task/9650355704888857576) started by @prateekmulye*