### PR TITLE
🎨 Palette: Add confirmation dialog for clearing conversation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-02 - Add Confirmation Dialog for Destructive Actions
+**Learning:** Users can easily lose context if they accidentally click the clear conversation button without a confirmation dialog. It's crucial to prevent accidental data loss in chat interfaces.
+**Action:** Add an `@st.dialog` confirmation step for any action that deletes history or user data.

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -210,11 +210,8 @@ def render_sidebar() -> None:
 
         # Clear conversation button
         if st.button("🗑️ Clear Conversation", use_container_width=True):
-            st.session_state.messages = []
-            st.session_state.agent_state = None
-            st.session_state.feedback = {}
-            logger.info("conversation_cleared", session_id=st.session_state.session_id)
-            st.rerun()
+            from src.ui.components import confirm_clear_dialog
+            confirm_clear_dialog()
 
         # New session button
         if st.button("🆕 New Session", use_container_width=True):

--- a/src/ui/components.py
+++ b/src/ui/components.py
@@ -958,6 +958,26 @@ def render_typing_indicator() -> None:
             st.empty()
 
 
+@st.dialog("Confirm Clear")
+def confirm_clear_dialog() -> None:
+    """Render a confirmation dialog for clearing the conversation."""
+    st.warning("Are you sure you want to clear the conversation? This action cannot be undone.")
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.button("Cancel", use_container_width=True):
+            st.rerun()
+    with col2:
+        if st.button("Yes, clear it", use_container_width=True, type="primary"):
+            st.session_state.messages = []
+            st.session_state.agent_state = None
+            st.session_state.feedback = {}
+            logger.info(
+                "conversation_cleared",
+                session_id=st.session_state.get("session_id", "unknown"),
+            )
+            st.rerun()
+
+
 def render_error_message(error: str, show_details: bool = False) -> None:
     """Render user-friendly error message.
 
@@ -1526,14 +1546,7 @@ def render_settings_panel() -> None:
                 key="settings_clear",
                 help="Delete all messages in the current conversation",
             ):
-                st.session_state.messages = []
-                st.session_state.agent_state = None
-                st.session_state.feedback = {}
-                logger.info(
-                    "conversation_cleared",
-                    session_id=st.session_state.get("session_id", "unknown"),
-                )
-                st.rerun()
+                confirm_clear_dialog()
 
         with col2:
             if st.button(


### PR DESCRIPTION
💡 What: Added an `@st.dialog` confirmation step before clearing the conversation history.
🎯 Why: To prevent accidental data loss when users click the "Clear Conversation" button.
📸 Before/After: Before, clicking clear conversation instantly deleted all messages. After, a confirmation dialog appears requiring a second click to confirm.
♿ Accessibility: Provided clear labels and semantic actions ("Cancel" and "Yes, clear it") for screen readers and keyboard navigation.

---
*PR created automatically by Jules for task [4874380364555370334](https://jules.google.com/task/4874380364555370334) started by @prateekmulye*