### PR TITLE
🎨 Palette: Add max_chars to chat input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-02 - Streamlit st.chat_input character limit UX
+**Learning:** Relying solely on server-side validation for character limits in chat interfaces leads to a poor user experience, as users can type indefinitely before receiving an error.
+**Action:** When using Streamlit UI components like `st.chat_input`, always utilize built-in parameters like `max_chars` to provide real-time visual feedback and client-side limits before submission.

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -439,6 +439,7 @@ def render_chat_interface(agent: Optional[F1AgentGraph]) -> None:
         "Ask me anything about Formula 1...",
         key="chat_input",
         disabled=agent is None,
+        max_chars=500,
     ):
         # Validate input
         if not prompt.strip():


### PR DESCRIPTION
💡 What: Added max_chars=500 parameter to st.chat_input component.
🎯 Why: Provides real-time visual feedback and client-side character limits, rather than relying solely on post-submission Python-side validation, improving user experience.
📸 Before/After: Before, user could type indefinitely and only get error after submission. After, user gets a character counter and is prevented from typing past 500 characters.
♿ Accessibility: Better feedback to users on character limits before action.

---
*PR created automatically by Jules for task [17425153291178977884](https://jules.google.com/task/17425153291178977884) started by @prateekmulye*