### PR TITLE
🎨 Palette: Add real-time character limit feedback to chat input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-15 - Add real-time character limit feedback
+**Learning:** When using Streamlit's st.chat_input in UI components, utilize the built-in max_chars parameter for real-time visual feedback and client-side character limits, rather than relying solely on post-submission Python-side validation to improve UX.
+**Action:** Use max_chars=N in st.chat_input whenever there is a length limit.

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -439,6 +439,7 @@ def render_chat_interface(agent: Optional[F1AgentGraph]) -> None:
         "Ask me anything about Formula 1...",
         key="chat_input",
         disabled=agent is None,
+        max_chars=500,
     ):
         # Validate input
         if not prompt.strip():


### PR DESCRIPTION
💡 What: Added `max_chars=500` to the `st.chat_input` widget.
🎯 Why: Previously, users could type long messages and only find out they exceeded the limit after hitting submit, leading to frustration. Now, they get real-time visual feedback as they type.
📸 Before/After: Visual indicator added to the chat input field showing character usage out of 500.
♿ Accessibility: Provides immediate, visible constraints to the user before action is taken.

---
*PR created automatically by Jules for task [3836990101501682484](https://jules.google.com/task/3836990101501682484) started by @prateekmulye*