### PR TITLE
docs: v2 "Pit Wall" architecture blueprint and migration roadmap

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,466 +1,416 @@
-# ChatFormula1 Agent - Architecture Documentation
+# ChatFormula1 v2 — "Pit Wall" Architecture & Roadmap
 
-This document provides a comprehensive overview of the ChatFormula1 Agent architecture, including system design, component interactions, and data flow.
+**The blueprint for ChatFormula1 v2: an Elixir/Phoenix GraphQL gateway, a slimmed Python LangGraph inference engine, and a React/Apollo frontend — built to run on free tiers without feeling free.**
 
-## Table of Contents
+> ChatFormula1 is an unofficial fan project. It is not affiliated with, endorsed by, or connected to Formula 1, the FIA, or any F1 team. This disclaimer appears in the README, repo description, and site footer.
 
-- [System Overview](#system-overview)
-- [Architecture Diagrams](#architecture-diagrams)
-- [Component Details](#component-details)
-- [Data Flow](#data-flow)
-- [Technology Stack](#technology-stack)
-- [Design Decisions](#design-decisions)
+---
 
-## System Overview
+## 1. Executive Summary
 
-ChatFormula1 Agent is a conversational AI system built using RAG (Retrieval-Augmented Generation) architecture. It combines real-time F1 data retrieval, semantic search over historical knowledge, and large language models to provide expert-level Formula 1 insights.
+ChatFormula1 v2 is a public portfolio demo proving one author can design and ship a production-shaped system across **Elixir/OTP, GraphQL, and AI** — with each layer carrying real, inspectable engineering weight. The AI is deliberately *not* the only star.
 
-### Key Features
+**The shape:** three apps, two backend services, one database, one vector index.
 
-- **Real-time Data**: Latest F1 news and updates via Tavily Search API
-- **Historical Knowledge**: Semantic search over F1 history using Pinecone vector database
-- **Conversational AI**: Natural language interactions powered by OpenAI GPT models
-- **Agent Orchestration**: LangGraph-based workflow for intelligent query routing
-- **Multi-interface**: Both API and UI interfaces for different use cases
+- **`gateway/` (Elixir 1.18 / OTP 28, Phoenix 1.7+, Absinthe, Ecto/Postgres, Oban OSS)** — the *only* public backend and the application's center of gravity. It owns the entire GraphQL surface (queries, mutations, subscriptions), all conversation state, identity, rate limiting, API keys, budget enforcement, background jobs, and telemetry. Its OTP centerpiece is a **per-conversation GenServer** (DynamicSupervisor + Registry) with Postgres hydration, an in-process seq-numbered replay buffer for reconnecting subscribers, idle hibernation, and supervised streaming workers.
+- **`agent/` (Python 3.12, FastAPI, LangGraph)** — slimmed to a **stateless, internal-only inference engine**. It keeps the genuinely load-bearing ~40% of the current codebase (the LangGraph pipeline, Pinecone retrieval, Tavily search, inference caches, prompt-injection guards) and deletes the dead ~60% (unwired nodes.py, memory.py, the never-bound tool layer, ~900 lines of unused prompts, Streamlit and its 1,540 lines of UI tests). One NDJSON streaming endpoint in, typed events out.
+- **`web/` (React 18, TypeScript, Vite, Apollo Client, Tailwind, shadcn/ui)** — a static dark, F1-inspired cockpit on Vercel. Streaming chat with a live "pit wall" telemetry strip rendering LangGraph node transitions, standings/calendar pages from pure GraphQL queries, and a public ops panel rendering real BEAM stats.
 
-## Architecture Diagrams
+**The headline demo:** a `sendMessage` mutation streams LLM tokens from LangGraph through a supervised BEAM process tree into an Absinthe GraphQL subscription, rendered token-by-token in Apollo — while the UI shows which pipeline node is executing. Kill the Python service mid-stream on camera: the supervisor publishes a normalized error, the circuit breaker opens, the UI degrades gracefully, and every other conversation keeps streaming.
 
-### High-Level System Architecture
+**Survivability:** wake-on-paint choreography hides free-tier cold starts behind the landing page; a **SHOWCASE mode** token-replays pre-generated answers through the *identical* publish path (with an honest "replayed from cache" badge) when the daily LLM budget is spent or the agent is down — so a recruiter at 3 a.m. always sees a streaming demo. A nightly Oban job syncs 2026 standings from the free Jolpica/Ergast API so the non-AI GraphQL data stays alive without LLM spend.
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         User Layer                               │
-│  ┌──────────────────┐              ┌──────────────────┐         │
-│  │  Streamlit UI    │              │   API Clients    │         │
-│  │  (Port 8501)     │              │   (REST/HTTP)    │         │
-│  └────────┬─────────┘              └────────┬─────────┘         │
-└───────────┼──────────────────────────────────┼──────────────────┘
-            │                                  │
-            └──────────────┬───────────────────┘
-                           │
-┌──────────────────────────┼──────────────────────────────────────┐
-│                    Application Layer                             │
-│                           │                                      │
-│  ┌────────────────────────▼────────────────────────┐            │
-│  │         FastAPI Backend (Port 8000)             │            │
-│  │  ┌──────────────────────────────────────────┐   │            │
-│  │  │      LangGraph Agent Orchestrator        │   │            │
-│  │  │  ┌────────────────────────────────────┐  │   │            │
-│  │  │  │  Query Analysis → Route Decision   │  │   │            │
-│  │  │  │         ↓              ↓            │  │   │            │
-│  │  │  │  Vector Search   Tavily Search     │  │   │            │
-│  │  │  │         ↓              ↓            │  │   │            │
-│  │  │  │    Context Ranking & Fusion        │  │   │            │
-│  │  │  │              ↓                      │  │   │            │
-│  │  │  │      LLM Response Generation       │  │   │            │
-│  │  │  └────────────────────────────────────┘  │   │            │
-│  │  └──────────────────────────────────────────┘   │            │
-│  └─────────────────────────────────────────────────┘            │
-└──────────────────────────┬──────────────────────────────────────┘
-                           │
-            ┌──────────────┼──────────────┐
-            │              │              │
-┌───────────▼────┐  ┌──────▼──────┐  ┌───▼──────────┐
-│   Pinecone     │  │   Tavily    │  │   OpenAI     │
-│ Vector Store   │  │ Search API  │  │   LLM API    │
-│                │  │             │  │              │
-│ - Embeddings   │  │ - Web Search│  │ - GPT-4      │
-│ - Similarity   │  │ - F1 News   │  │ - Embeddings │
-│   Search       │  │ - Real-time │  │ - Streaming  │
-└────────────────┘  └─────────────┘  └──────────────┘
-```
+**Cost: $0/month fixed.** The only variable exposure is OpenAI tokens (default **gpt-4o-mini** behind a provider seam), capped by a hand-rolled ETS rate limiter, a hard daily USD ledger, and an account-level billing cap.
 
-### RAG Pipeline Architecture
+---
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                      User Query Input                            │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Query Analysis Node                           │
-│  - Intent Detection (historical vs current vs prediction)        │
-│  - Entity Extraction (drivers, teams, races, years)             │
-│  - Query Classification (factual, analytical, conversational)    │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Routing Decision Node                         │
-│  - Vector Search Only (historical queries)                       │
-│  - Tavily Search Only (current events)                          │
-│  - Hybrid Search (requires both)                                │
-└────────────┬───────────────┬────────────────┬───────────────────┘
-             │               │                │
-    ┌────────▼────┐   ┌──────▼──────┐   ┌────▼─────────┐
-    │   Vector    │   │   Tavily    │   │    Both      │
-    │   Search    │   │   Search    │   │  (Parallel)  │
-    └────────┬────┘   └──────┬──────┘   └────┬─────────┘
-             │               │                │
-             └───────────────┼────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                  Context Ranking & Fusion Node                   │
-│  - Score relevance of retrieved documents                        │
-│  - Deduplicate information                                       │
-│  - Merge vector and search results                              │
-│  - Select top K most relevant contexts                          │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   Prompt Construction Node                       │
-│  - System prompt (F1 expert persona)                            │
-│  - Retrieved context (formatted)                                │
-│  - Conversation history                                         │
-│  - User query                                                   │
-│  - Output format instructions                                   │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   LLM Generation Node                            │
-│  - OpenAI GPT-4 / GPT-3.5                                       │
-│  - Streaming response                                           │
-│  - Citation generation                                          │
-│  - Confidence scoring                                           │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                  Response Formatting Node                        │
-│  - Markdown formatting                                          │
-│  - Source attribution                                           │
-│  - Metadata attachment                                          │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      Response to User                            │
-└─────────────────────────────────────────────────────────────────┘
+## 2. System Architecture
+
+### Service boundary principle
+
+**The Elixir gateway IS the application. Python is a stateless inference engine. React is a rendering surface.** Everything with state, identity, policy, or scheduling lives on the BEAM; everything that must survive a restart lives in Postgres.
+
+| Concern | Owner | Notes |
+|---|---|---|
+| GraphQL queries / mutations / subscriptions | Gateway | GraphiQL public (read-rate-limited) as a demo artifact |
+| Conversation + message persistence | Gateway (Ecto/Postgres) | Replaces `chat.py`'s in-memory `session_storage` MemorySaver dict; fixes restart-loss + IDOR in one move |
+| Hot conversation state, replay buffers | Gateway (per-conversation GenServer) | Hydrates from Postgres; idle timeout + `:hibernate` |
+| Identity (anonymous viewer tokens, API keys) | Gateway | Signed `Phoenix.Token` cookies; `f1s_`-prefixed keys, SHA-256 at rest, scopes — **enforced** via plug + Absinthe middleware, fixing the never-registered `AuthenticationMiddleware` theater |
+| Rate limiting + daily LLM budget ledger | Gateway | Hand-rolled ETS dual-window token bucket; Postgres budget row flips SHOWCASE mode |
+| Transport-level input validation | Gateway | Length 1–2000, repeated-char DoS, control-char/HTML strip — Absinthe input objects + changesets |
+| Structured F1 data (drivers/constructors/races/results/standings) | Gateway (Postgres) | Seeded from `data/*.json`, refreshed nightly via Jolpica/Ergast Oban job — the zero-LLM-cost GraphQL depth showcase |
+| Background jobs, telemetry, observability | Gateway | Oban OSS + Cron, `:telemetry` + PromEx + LiveDashboard |
+| LangGraph pipeline (analyze → route → retrieve → rank → generate) | Agent | `import asyncio` bug fixed; graph compiled **once** at startup; no checkpointer |
+| Pinecone retrieval, Tavily search, inference TTL caches | Agent | Deterministic vector IDs + namespaces; migrated to `langchain-tavily` |
+| Prompt-injection heuristics | Agent | They belong next to the LLM |
+| Offline ingestion CLI | Agent | Persisted dedup state, SHA-256 hashing, `make reindex` rebuilds Pinecone from scratch |
+| Rendering, optimistic UI, wake-on-paint ping | Web | Zero business logic, zero secrets |
+
+### Topology diagram
+
+```mermaid
+flowchart LR
+    subgraph Edge["Vercel (static, always-on)"]
+        WEB["web/ — React 18 + TS + Apollo\ndark F1 cockpit, wake-on-paint ping"]
+    end
+
+    subgraph Fly["Fly.io — always-on 1x shared-cpu 256MB"]
+        subgraph GW["gateway/ — Phoenix 1.7 + Absinthe (ONLY public backend)"]
+            SCHEMA["Absinthe schema\nqueries / mutations / subscriptions\nDataloader, complexity + depth limits"]
+            CONV["Conversation.Server GenServers\nDynamicSupervisor + Registry\nreplay buffer (seq), hydrate, hibernate"]
+            RL["ETS token-bucket rate limiter\n+ daily USD budget ledger"]
+            BRK["Circuit breaker GenServer\nclosed / open / half-open"]
+            OBAN["Oban OSS + Cron\nJolpica sync, news ingest, pruning,\ntitle gen, spend rollup, cache warming"]
+            TEL["Telemetry → PromEx + LiveDashboard\npublic systemStats query"]
+        end
+    end
+
+    subgraph Render["Render free (sleeps; cold start is designed UX)"]
+        AGENT["agent/ — FastAPI + LangGraph (internal-only)\nPOST /internal/chat (NDJSON stream)\nPOST /internal/ingest · GET /internal/health\nstateless: history in, events out"]
+    end
+
+    PG[("Supabase Postgres\nconversations, messages, F1 data,\nAPI keys, budget ledger, Oban,\ncached showcase answers")]
+    PINE[("Pinecone Starter\n'f1-knowledge' index\nnamespaces: static_corpus / news")]
+    LLM["OpenAI gpt-4o-mini\n(provider factory seam)"]
+    TAV["Tavily (1000/mo free)"]
+    JOL["Jolpica / Ergast API (free)"]
+
+    WEB -- "HTTPS: queries + mutations\nWSS: graphql-ws subscriptions\n(absinthe_graphql_ws)" --> SCHEMA
+    SCHEMA --> CONV
+    CONV -- "Req/Finch streaming POST\nbearer token, NDJSON" --> AGENT
+    GW --- PG
+    AGENT --- PINE
+    AGENT --- LLM
+    AGENT --- TAV
+    OBAN --- JOL
+    OBAN -- "ingest trigger" --> AGENT
 ```
 
-### Data Ingestion Pipeline
+**Wake-on-paint choreography:** the frontend's first paint fires `GET /up` at the gateway; the gateway's warmup process immediately pings `agent/internal/health`, so Render's 30–60 s cold start burns while the visitor is still reading the hero copy. If a visitor types instantly, the stream opens with `WARMING_UP` pipeline events rendered as pit-radio chatter — a designed state with its own UI pass, never a dead spinner.
+
+---
+
+## 3. Absinthe GraphQL Schema (SDL)
+
+Served with **query complexity analysis and max-depth limits** (cheap insurance on a public GraphiQL endpoint), Dataloader-batched associations, and a custom middleware stack (viewer auth → API-key scopes → rate limit → input validation → error normalization).
+
+```graphql
+scalar DateTime
+
+# ─────────── F1 structured data (Postgres + Dataloader; zero LLM cost) ───────────
+type Driver {
+  id: ID!
+  code: String!
+  number: Int!
+  fullName: String!
+  nationality: String!
+  constructor: Constructor!          # Dataloader — provable no-N+1
+  results(season: Int): [RaceResult!]!
+}
+type Constructor { id: ID!, name: String!, points: Float!, drivers: [Driver!]! }
+type Race {
+  id: ID!
+  season: Int!
+  round: Int!
+  name: String!
+  circuit: String!
+  country: String!
+  startsAt: DateTime!
+  results: [RaceResult!]!
+}
+type RaceResult {
+  driver: Driver!
+  race: Race!
+  gridPosition: Int
+  finishPosition: Int
+  points: Float!
+  podium: Boolean!
+}
+type StandingRow { position: Int!, driver: Driver!, points: Float!, wins: Int!, podiums: Int! }
+
+# ─────────── Conversations ───────────
+enum MessageRole { USER ASSISTANT }
+enum MessageStatus { PENDING STREAMING COMPLETE FAILED }
+type Conversation {
+  id: ID!
+  title: String
+  insertedAt: DateTime!
+  messages(first: Int, before: String): [Message!]!
+}
+type Message {
+  id: ID!
+  role: MessageRole!
+  content: String!
+  status: MessageStatus!
+  intent: String
+  sources: [Source!]!
+  cached: Boolean!
+  latencyMs: Int
+  insertedAt: DateTime!
+}
+type Source { kind: SourceKind!, title: String!, url: String, snippet: String, score: Float }
+enum SourceKind { VECTOR WEB }
+
+# ─────────── Agent stream events (subscription payload — union showcase) ───────────
+union AgentEvent =
+    TokenDelta
+  | NodeTransition
+  | SourcesResolved
+  | MessageCompleted
+  | AgentError
+
+type TokenDelta { messageId: ID!, seq: Int!, text: String! }
+type NodeTransition { messageId: ID!, node: AgentNode!, startedAt: DateTime! }
+enum AgentNode {
+  WARMING_UP          # agent cold-starting (Render wake)
+  ANALYZE_QUERY
+  ROUTE
+  VECTOR_SEARCH
+  WEB_SEARCH
+  PARALLEL_RETRIEVAL
+  RANK_CONTEXT
+  GENERATE
+  FORMAT_RESPONSE
+  REPLAYING_CACHE     # SHOWCASE-mode token replay
+}
+type SourcesResolved { messageId: ID!, sources: [Source!]! }
+type MessageCompleted { messageId: ID!, message: Message!, cached: Boolean!, usage: TokenUsage }
+type TokenUsage { promptTokens: Int!, completionTokens: Int!, estimatedCostUsd: Float! }
+type AgentError { messageId: ID!, code: ErrorCode!, message: String!, retryable: Boolean! }
+enum ErrorCode { UPSTREAM_UNAVAILABLE RATE_LIMITED BUDGET_EXHAUSTED VALIDATION INTERNAL }
+
+# ─────────── Ops (the Elixir showcase, queryable) ───────────
+enum ServiceMode { LIVE DEGRADED SHOWCASE }   # SHOWCASE = budget spent / agent down → cached replay
+type RateLimitStatus {
+  limitPerMinute: Int!
+  remainingMinute: Int!
+  limitPerHour: Int!
+  remainingHour: Int!
+  resetsAt: DateTime!
+}
+type SystemHealth {
+  mode: ServiceMode!
+  gateway: ServiceStatus!
+  agentService: ServiceStatus!
+  database: ServiceStatus!
+  breakerState: BreakerState!
+}
+enum ServiceStatus { HEALTHY DEGRADED DOWN }
+enum BreakerState { CLOSED OPEN HALF_OPEN }
+type SystemStats {
+  activeConversations: Int!
+  beamProcessCount: Int!
+  uptimeSeconds: Int!
+  p95FirstTokenMs: Int
+  tokensPerSecond: Float
+  obanJobsCompleted24h: Int!
+  lastStandingsSyncAt: DateTime
+  llmSpendTodayUsd: Float!
+  dailyBudgetRemainingUsd: Float!
+}
+
+type Query {
+  drivers(season: Int): [Driver!]!
+  driver(code: String!): Driver
+  races(season: Int!): [Race!]!
+  nextRace: Race                       # homepage countdown
+  standings(season: Int!): [StandingRow!]!
+  conversation(id: ID!): Conversation  # scoped to viewer token — fixes the inherited IDOR
+  conversations: [Conversation!]!      # viewer's own only; no global enumeration
+  demoQuestions: [String!]!            # chips wired to pre-warmed SHOWCASE answers
+  rateLimitStatus: RateLimitStatus!
+  systemHealth: SystemHealth!
+  systemStats: SystemStats!            # only telemetry-fed numbers — no theater
+}
+
+type Mutation {
+  startConversation: Conversation!
+  "Validates + persists user msg and assistant placeholder, kicks off the stream, returns immediately."
+  sendMessage(conversationId: ID!, content: String!): SendMessagePayload!
+  deleteConversation(id: ID!): Boolean!
+  submitFeedback(messageId: ID!, helpful: Boolean!): Boolean!
+  "Requires API key scope 'admin:ingest'; enqueues an Oban job. Allowlisted sources only."
+  triggerIngest(source: IngestSource!): IngestJob!
+}
+type SendMessagePayload { userMessage: Message!, assistantMessageId: ID! }
+enum IngestSource { NEWS HISTORICAL CALENDAR }
+type IngestJob { id: ID!, state: String!, queuedAt: DateTime! }
+
+type Subscription {
+  "Topic agent:<message_id>; subscription-time authorization against the viewer token."
+  agentStream(messageId: ID!): AgentEvent!
+  conversationUpdated(conversationId: ID!): Message!
+  systemHealthChanged: SystemHealth!   # lets the UI flip LIVE/SHOWCASE badges in real time
+}
+```
+
+---
+
+## 4. Token Streaming Design — End to End
+
+**The frozen interface between services is the NDJSON event protocol, documented in `docs/STREAMING_PROTOCOL.md` and enforced by CI contract tests on both sides** (a recorded NDJSON stream replayed against the Elixir parser via Bypass; a Python test asserting exact event sequence).
+
+### 4.1 Python emits NDJSON
+
+`POST /internal/chat` runs the once-compiled graph (no checkpointer, compiled at startup — the per-request recompilation pattern dies) via `astream_events` **v2**. The generation `ChatOpenAI` is constructed with `tags=["generation"]`; the handler forwards `on_chat_model_stream` **only** for that tag — this kills the current bug where `analyze_query`'s structured-output JSON leaks into the user-visible stream. One event per line on a chunked response:
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Data Sources                                  │
-│  - Historical race results (CSV)                                │
-│  - Driver statistics (JSON)                                     │
-│  - Circuit information                                          │
-│  - F1 regulations documents                                     │
-│  - Curated F1 articles                                          │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      Data Loader                                 │
-│  - Read CSV/JSON files                                          │
-│  - Validate data schemas                                        │
-│  - Handle encoding issues                                       │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   Document Processor                             │
-│  - Text extraction and cleaning                                 │
-│  - Semantic chunking (1000 chars, 200 overlap)                 │
-│  - Preserve context across chunks                              │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   Metadata Enricher                              │
-│  - Extract entities (drivers, teams, races)                     │
-│  - Add temporal metadata (year, season)                         │
-│  - Categorize content type                                      │
-│  - Add source attribution                                       │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   Embedding Generation                           │
-│  - OpenAI text-embedding-3-small                                │
-│  - Batch processing (100 docs/batch)                            │
-│  - Retry logic for failures                                     │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   Pinecone Upsert                                │
-│  - Batch upsert to vector store                                 │
-│  - Progress tracking                                            │
-│  - Error handling and logging                                   │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   Indexed Knowledge Base                         │
-└─────────────────────────────────────────────────────────────────┘
+{"event":"node_started","node":"vector_search"}
+{"event":"sources","items":[{"kind":"vector","title":"...","score":0.83}]}
+{"event":"token","text":"Verst"}
+{"event":"complete","content":"<full text>","cached":false,"usage":{"prompt_tokens":...,"completion_tokens":...}}
+{"event":"error","code":"...","retryable":true}
 ```
 
-### Conversation State Management
+LLM-cache hits legally emit **zero** `token` events and a single `complete` with `cached: true` — explicit in the contract, not a client surprise. Request body: `{message, history: [last-10 window], request_id}` — the agent is fully stateless; the gateway owns the thread.
+
+### 4.2 Mutation kicks off
+
+`sendMessage` resolver: Absinthe middleware chain (viewer auth → ETS rate limit → input validation) → `Ecto.Multi` inserts the user `Message` and an assistant `Message` placeholder (status `PENDING`) → ensures the `Conversation.Server` is running (Registry lookup-or-start under `DynamicSupervisor`) → `begin_stream(conv_id, assistant_msg_id)` → returns `{userMessage, assistantMessageId}` in <50 ms. No LLM work in the resolver.
+
+### 4.3 Mode gate, then StreamRunner
+
+`Conversation.Server` first checks the **budget ledger** and **circuit breaker**:
+
+- **Breaker open / budget exhausted → SHOWCASE path:** skip Python entirely. An Oban warming job has pre-generated answers for every `demoQuestions` entry (plus top real queries), stored with their **original token-timing histograms**. The server replays them through the *identical* publish path with timer-driven pacing — real `NodeTransition{REPLAYING_CACHE}`, `TokenDelta`, `MessageCompleted{cached: true}` events. The UI shows an honest "replayed from cache" badge. The demo streams convincingly at zero LLM spend.
+- **LIVE path:** start a monitored task under `ChatF1.StreamTaskSupervisor` (`Task.Supervisor`) that opens `Req.post!(agent_url, json: payload, into: reducer)` over Finch streaming. Chunks are line-buffered; each complete NDJSON line is decoded and cast to the `Conversation.Server`. If the agent is cold-starting, the runner emits `NodeTransition{WARMING_UP}` and retries with backoff up to 45 s. `:telemetry.span` wraps the call; the first token emits `[:chatf1, :agent, :first_token]` with TTFT.
+
+### 4.4 Conversation.Server fans out
+
+For each event the GenServer:
+
+1. Appends to its **replay buffer** with a monotonically increasing `seq` (hard cap: **32 KB per message**, oldest-token truncation);
+2. **Micro-batches tokens** — flush every 40 ms or 12 tokens via `Process.send_after` — so `Absinthe.Subscription.publish` is not called per token (PubSub + websocket frame overhead is real on a 256 MB machine);
+3. Publishes to topic `agent:<message_id>`: `node_started → NodeTransition` (drives the telemetry strip), `sources → SourcesResolved`, `complete → Ecto.Multi [update message content/status/usage, decrement budget ledger, insert telemetry rollup]` then `MessageCompleted`, `error → mark FAILED + AgentError`.
+
+### 4.5 Reliability semantics
+
+- **Reconnects:** `seq` numbers make gaps client-detectable. On re-subscribe, the resolver replays buffered events from the GenServer before going live. The frontend reducer is **idempotent by seq** (the replay/live overlap race has an explicit integration test). *Scope valve:* if Phase 3 slips, replay-buffer cuts to refetch-on-reconnect (the final message is always in Postgres — a dropped socket just refetches `conversation(id)`).
+- **Crashes:** if the StreamRunner or Python dies mid-stream, the `:DOWN` message marks the message `FAILED`, publishes a retryable `AgentError`, and increments the breaker. One crashed stream never touches other conversations — supervision is user-visible.
+- **Cache hits:** the gateway synthesizes one `TokenDelta` carrying the full text before `MessageCompleted`, so the frontend render path is uniform.
+- **Lifecycle:** idle `Conversation.Server`s self-terminate after 15 min (`handle_info(:timeout)`); state survives in Postgres.
+
+### 4.6 Absinthe → Apollo
+
+Subscriptions ride Phoenix Channels over `Phoenix.PubSub` (PG2, single node — no Redis). The gateway exposes **standard `graphql-ws` via `absinthe_graphql_ws`** so Apollo uses its mainstream `GraphQLWsLink` (deliberately avoiding the stale `@absinthe/socket` packages). Apollo split link: HTTP for queries/mutations, WSS for subscriptions. The chat component subscribes per `assistantMessageId`, reduces `TokenDelta` batches into the streaming bubble (in-memory buffer; only `MessageCompleted` writes the normalized cache), and renders `NodeTransition` events as the live pipeline indicator. Subscription-time topic authorization checks the viewer token owns the message's conversation — no cross-tenant streaming.
+
+---
+
+## 5. Elixir/OTP Showcase Inventory
+
+Every item below is reachable from the live demo or readable in ≤2 files — no theater.
+
+1. **Documented supervision tree** (diagram + `:observer` screenshot in docs): `ChatF1.Application` supervising `Repo`, `Phoenix.PubSub`, `ConvRegistry` (Registry), `ConversationSupervisor` (DynamicSupervisor), `StreamTaskSupervisor` (Task.Supervisor), `Agents.Breaker`, Finch pool, Oban, PromEx, `Endpoint` — with a scripted kill-a-GenServer-mid-demo showing crash isolation.
+2. **Per-conversation GenServer** (`ChatF1.Conversations.Server`): Registry via-tuples, lazy start, Postgres hydration, idle `:timeout` + `:hibernate`, and a capped seq-numbered **replay buffer** re-feeding reconnecting subscribers — the OTP money shot.
+3. **Absinthe depth:** Dataloader (Ecto source) batching driver→constructor→results (provable no-N+1 on standings), **query complexity + max-depth analysis**, union-typed subscription payloads (`AgentEvent`), custom middleware stack with normalized `ErrorCode` errors.
+4. **Absinthe.Subscription over Phoenix.PubSub** with per-message topics, subscription-time authorization, and micro-batched publishes (40 ms / 12 tokens) — a real backpressure decision.
+5. **Hand-rolled ETS dual-window token-bucket rate limiter** (per-minute burst + per-hour) as a GenServer-owned ETS table + Plug + Absinthe middleware, emitting telemetry on allow/deny, queryable via `rateLimitStatus` — deliberately not Hammer; "I built it" is the interview line.
+6. **Circuit breaker GenServer** (closed/open/half-open with timed probe) guarding the Python upstream, surfaced in `systemHealth`, wired to Render cold-start reality — failure handling as a feature.
+7. **Oban OSS + Cron:** nightly **Jolpica/Ergast standings sync** (unique jobs, exponential backoff — self-maintaining 2026 data), nightly Tavily news-ingest trigger, daily conversation TTL pruning, conversation title generation, SHOWCASE cache warming, daily LLM-spend rollup flipping `ServiceMode`.
+8. **Telemetry as a first-class surface:** `:telemetry.span` around the agent stream (TTFT, tokens/sec, per-node durations), Phoenix/Ecto/Absinthe/Oban metrics via PromEx, LiveDashboard behind API-key auth, and a curated public `systemStats` query rendered as the frontend pit-wall panel — only telemetry-fed numbers.
+9. **Task.Supervisor-monitored streaming HTTP client** (Req/Finch `into:` reducer with NDJSON line-buffering) and `:DOWN`-based cleanup — process monitoring doing real work.
+10. **Phoenix.Token anonymous viewer identity** + Postgres-backed API keys (`f1s_` prefix, SHA-256 at rest, scope wildcards, rotate/revoke, raw key shown once) — *enforced for the first time in this project's history*.
+11. **Ecto.Multi transactional message lifecycle** + changeset validation mirrored into Absinthe input objects.
+12. **Daily USD budget ledger** in Postgres (decremented from agent-reported usage) driving SHOWCASE mode — the real FreeTierLimiter the old README only pretended existed.
+13. **Mix release** with `runtime.exs`, `Oban.Notifiers.PG` (single-node, pooler-safe), `/healthz` and `/up` plugs.
+14. **ExUnit story:** Absinthe.run schema tests, `Phoenix.ChannelTest` subscription tests (including kill-the-runner-mid-stream and the reconnect/replay race), `Oban.Testing` for jobs, **Bypass** contract tests replaying recorded NDJSON against the parser.
+
+---
+
+## 6. Monorepo Layout
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                      User Session                                │
-│  - Session ID                                                    │
-│  - User preferences                                             │
-│  - Conversation history                                         │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   LangGraph Memory Saver                         │
-│  - Checkpoint conversation state                                │
-│  - Sliding window (last 10 messages)                            │
-│  - Context summarization for long conversations                 │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Agent State                                   │
-│  {                                                              │
-│    "messages": [...],                                           │
-│    "query": "...",                                              │
-│    "intent": "...",                                             │
-│    "entities": {...},                                           │
-│    "retrieved_docs": [...],                                     │
-│    "search_results": [...],                                     │
-│    "context": "...",                                            │
-│    "response": "...",                                           │
-│    "metadata": {...}                                            │
-│  }                                                              │
-└─────────────────────────────────────────────────────────────────┘
+chatformula1/
+├── README.md                  # 30-sec sell: hero GIF of token streaming, mermaid diagram,
+│                              # "three files to read" (conversations/server.ex, schema.ex, graph.py),
+│                              # quickstart, CI badges, disclaimer, free-tier honesty notes
+├── LICENSE
+├── Makefile                   # make setup / dev / test / lint / demo / reindex — fans out to all apps
+├── docker-compose.yml         # postgres:16 + agent for local dev (gateway runs native via mix)
+├── data/                      # races.json, drivers.json, historical_features.csv,
+│                              # showcase_answers.json (gateway seeds + agent ingestion input)
+├── docs/
+│   ├── ARCHITECTURE.md        # supervision tree diagram, service boundary, token path narrative
+│   ├── STREAMING_PROTOCOL.md  # the frozen NDJSON event contract + AgentEvent mapping
+│   ├── GRAPHQL.md             # schema tour + example operations
+│   ├── DEPLOYMENT.md          # Fly/Render/Supabase/Pinecone/Vercel free-tier runbook
+│   └── adr/
+│       ├── 000-single-node-invariants.md   # ETS limiter, local PubSub, replay buffers,
+│       │                                   # Oban.Notifiers.PG all assume ONE machine; count pinned in fly.toml
+│       ├── 001-two-services.md
+│       ├── 002-ndjson-over-sse.md
+│       ├── 003-supabase-over-neon.md       # Oban polling burns Neon's ~190 free compute-hrs in ~8 days
+│       ├── 004-showcase-mode.md
+│       └── 005-handrolled-rate-limiter.md
+├── .github/workflows/
+│   ├── gateway.yml            # path-filtered: mix format --check, credo, dialyzer (cached PLT), mix test
+│   ├── agent.yml              # path-filtered: ruff, mypy, pytest — DUMMY KEYS ONLY
+│   ├── web.yml                # path-filtered: tsc, eslint, vitest, codegen drift check
+│   └── wake-cron.yml          # daily wake-ping; doubles as uptime check — opens a GitHub issue on failure
+├── gateway/                   # Elixir 1.18 / OTP 28 / Phoenix 1.7 — THE application
+│   ├── mix.exs
+│   ├── fly.toml               # min/max machine count pinned to 1 (ADR-000)
+│   ├── config/{config,dev,test,prod,runtime}.exs
+│   ├── lib/chat_f1/
+│   │   ├── application.ex     # the supervision tree, heavily commented
+│   │   ├── conversations/     # context + server.ex (GenServer) + stream_runner.ex
+│   │   ├── formula1/          # drivers/constructors/races/results context + standings + jolpica_sync
+│   │   ├── agents/            # client.ex (Req/Finch NDJSON), breaker.ex, events.ex
+│   │   ├── rate_limit/        # ETS token bucket GenServer + plug + absinthe middleware
+│   │   ├── budget/            # daily USD ledger + ServiceMode
+│   │   ├── showcase/          # cached answers + timing-histogram replayer
+│   │   ├── accounts/          # viewer tokens, api_keys
+│   │   ├── workers/           # Oban: jolpica_sync, ingest_news, prune_conversations,
+│   │   │                      #       title_gen, spend_rollup, warm_showcase_cache
+│   │   └── telemetry/         # promex.ex, span helpers
+│   ├── lib/chat_f1_web/
+│   │   ├── endpoint.ex / router.ex / channels/
+│   │   └── schema/            # schema.ex, types/, resolvers/, middleware/, dataloader source
+│   ├── priv/repo/{migrations,seeds.exs}    # seeds from ../data
+│   └── test/                  # contexts, resolvers, subscription integration (kill-mid-stream,
+│                              # reconnect race), rate limiter, breaker, Oban.Testing, Bypass contract
+├── agent/                     # slimmed Python 3.12 LangGraph service — internal-only
+│   ├── pyproject.toml         # exact-pinned langgraph/langchain; no streamlit, no isort-in-runtime
+│   ├── Dockerfile             # reuses existing builder/production stages
+│   ├── src/chatf1_agent/
+│   │   ├── graph.py           # fixed F1AgentGraph (+ import asyncio, tags=["generation"],
+│   │   │                      #  ContextScore ranking salvaged, dynamic year)
+│   │   ├── state.py           # AgentState + QueryAnalysis ONLY
+│   │   ├── prompts.py         # F1_EXPERT_SYSTEM_PROMPT
+│   │   ├── providers.py       # LLM factory seam — gpt-4o-mini default
+│   │   ├── retrieval/         # vector_store.py (namespaces, deterministic IDs), tavily.py (langchain-tavily)
+│   │   ├── guards.py          # prompt-injection heuristics
+│   │   ├── caching.py         # inference-path TTL caches (single-replica by design)
+│   │   └── server.py          # FastAPI: /internal/chat (NDJSON), /internal/ingest, /internal/health
+│   ├── ingestion/             # offline CLI pipeline (persisted dedup state, SHA-256, deterministic IDs)
+│   └── tests/                 # salvaged: security, prompts, processor, loader, graph integration
+│                              # + NDJSON contract test (exact event sequence)
+└── web/                       # React 18 + TS + Vite + Apollo + Tailwind + shadcn/ui
+    ├── src/
+    │   ├── graphql/           # .graphql documents + codegen output (typed hooks)
+    │   ├── components/{chat,telemetry,standings,layout}/
+    │   ├── lib/apollo.ts      # split link: HttpLink + GraphQLWsLink (graphql-ws → absinthe_graphql_ws)
+    │   ├── routes/            # Chat (default), Standings, Calendar, Driver, About/Architecture
+    │   └── theme/             # dark carbon-fiber F1 theme
+    ├── codegen.ts
+    └── vite.config.ts
 ```
 
-## Component Details
+---
 
-### 1. FastAPI Backend
+## 7. Free-Tier Hosting Topology
 
-**Responsibilities**:
-- HTTP request handling
-- API endpoint routing
-- Request validation
-- Response formatting
-- CORS management
-- Rate limiting
-- Health checks
+Two backend services (constraint-compliant), $0/month fixed.
 
-**Key Endpoints**:
-- `POST /chat` - Process chat messages
-- `GET /health` - Health check
-- `POST /ingest` - Trigger data ingestion
-- `GET /stats` - Vector store statistics
-
-### 2. LangGraph Agent
-
-**Responsibilities**:
-- Conversation orchestration
-- Query routing
-- Tool execution
-- State management
-- Error handling
-- Response streaming
-
-**Nodes**:
-- `analyze_query` - Intent detection and entity extraction
-- `route` - Decide which retrieval strategy to use
-- `vector_search` - Query Pinecone vector store
-- `tavily_search` - Query Tavily search API
-- `rank_context` - Score and merge results
-- `generate` - LLM response generation
-
-### 3. Vector Store Manager
-
-**Responsibilities**:
-- Pinecone connection management
-- Document embedding
-- Similarity search
-- Metadata filtering
-- Index statistics
-
-**Key Methods**:
-- `upsert_documents()` - Add documents to vector store
-- `similarity_search()` - Retrieve similar documents
-- `hybrid_search()` - Combine semantic and keyword search
-
-### 4. Tavily Search Client
-
-**Responsibilities**:
-- Real-time web search
-- F1-specific domain filtering
-- Result parsing
-- Rate limiting
-- Error handling
-
-**Key Methods**:
-- `search()` - Execute search query
-- `search_with_context()` - Contextual search
-- `crawl_f1_source()` - Deep content extraction
-
-### 5. Prompt Templates
-
-**Responsibilities**:
-- Structured prompt construction
-- Context formatting
-- Few-shot examples
-- Output format specification
-- Guardrails
-
-**Templates**:
-- System prompts (role definition)
-- RAG prompts (context + query)
-- Specialized prompts (predictions, analysis)
-
-### 6. Streamlit UI
-
-**Responsibilities**:
-- User interface rendering
-- Chat history display
-- Message input handling
-- Streaming response display
-- Source citation display
-- Session management
-
-**Components**:
-- Chat interface
-- Sidebar settings
-- Message history
-- Source expandables
-
-## Data Flow
-
-### Query Processing Flow
-
-1. **User Input** → User submits query via UI or API
-2. **Query Analysis** → Extract intent and entities
-3. **Routing Decision** → Determine retrieval strategy
-4. **Parallel Retrieval** → Query vector store and/or search API
-5. **Context Ranking** → Score and merge results
-6. **Prompt Construction** → Build structured prompt
-7. **LLM Generation** → Generate response with streaming
-8. **Response Formatting** → Format with citations
-9. **User Output** → Display to user
-
-### Data Ingestion Flow
-
-1. **Data Loading** → Read source files
-2. **Document Processing** → Clean and chunk text
-3. **Metadata Enrichment** → Add structured metadata
-4. **Embedding Generation** → Convert to vectors
-5. **Vector Store Upsert** → Store in Pinecone
-6. **Verification** → Validate ingestion
-
-## Technology Stack
-
-### Core Technologies
-
-- **Python 3.11** - Application runtime
-- **Poetry** - Dependency management
-- **FastAPI** - Web framework
-- **Streamlit** - UI framework
-- **Docker** - Containerization
-
-### AI/ML Stack
-
-- **LangChain** - LLM framework
-- **LangGraph** - Agent orchestration
-- **OpenAI GPT-4** - Language model
-- **OpenAI Embeddings** - Text embeddings
-- **Pinecone** - Vector database
-- **Tavily** - Search API
-
-### Infrastructure
-
-- **Docker Compose** - Local orchestration
-- **Nginx** - Reverse proxy (optional)
-- **Kubernetes** - Production orchestration (optional)
-
-### Observability
-
-- **Structlog** - Structured logging
-- **LangSmith** - LLM tracing
-- **Prometheus** - Metrics (optional)
-
-## Design Decisions
-
-### Why LangGraph?
-
-- **State Management**: Built-in conversation state handling
-- **Flexibility**: Easy to modify agent workflow
-- **Observability**: Native LangSmith integration
-- **Streaming**: First-class streaming support
-
-### Why Pinecone?
-
-- **Managed Service**: No infrastructure management
-- **Performance**: Fast similarity search
-- **Scalability**: Handles large datasets
-- **Metadata Filtering**: Rich query capabilities
-
-### Why Tavily?
-
-- **F1-Specific**: Can filter by trusted F1 domains
-- **Real-time**: Latest news and updates
-- **Quality**: AI-powered relevance ranking
-- **Reliability**: High uptime and rate limits
-
-### Why Streamlit?
-
-- **Rapid Development**: Quick to build UI
-- **Python-Native**: No JavaScript required
-- **Rich Components**: Built-in chat interface
-- **Easy Deployment**: Simple hosting options
-
-### Architectural Patterns
-
-1. **RAG Pattern**: Combines retrieval with generation for accuracy
-2. **Agent Pattern**: Intelligent routing and tool use
-3. **Multi-stage Build**: Optimized Docker images
-4. **Dependency Injection**: Testable and maintainable code
-5. **Graceful Degradation**: Fallbacks for API failures
-
-### Trade-offs
-
-| Decision | Pros | Cons |
-|----------|------|------|
-| Python-only stack | Unified language, easier maintenance | May be slower than compiled languages |
-| Managed services | Less ops overhead | Vendor lock-in, costs |
-| Streamlit UI | Fast development | Limited customization |
-| Docker deployment | Consistent environments | Additional complexity |
-| Synchronous API | Simpler code | Lower throughput |
-
-## Future Enhancements
-
-### Planned Improvements
-
-1. **Caching Layer**: Redis for response caching
-2. **Async Operations**: Full async/await throughout
-3. **Multi-modal**: Image analysis for race incidents
-4. **Personalization**: User preference learning
-5. **Advanced Analytics**: Deeper statistical analysis
-6. **Real-time Updates**: WebSocket for live race data
-7. **Mobile App**: Native mobile experience
-8. **Multi-language**: Internationalization support
-
-### Scalability Considerations
-
-- Horizontal scaling of API instances
-- Load balancing across replicas
-- Distributed caching with Redis
-- CDN for static assets
-- Database connection pooling
-- Rate limiting per user
-- Circuit breakers for external APIs
-
-## References
-
-- [LangChain Documentation](https://python.langchain.com/)
-- [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
-- [Pinecone Documentation](https://docs.pinecone.io/)
-- [Tavily Documentation](https://docs.tavily.com/)
-- [FastAPI Documentation](https://fastapi.tiangolo.com/)
-- [Streamlit Documentation](https://docs.streamlit.io/)
+| Component | Provider | Configuration & rationale |
+|---|---|---|
+| **Gateway** | **Fly.io** — 1× shared-cpu-1x **256 MB**, `auto_stop_machines = false`, machine count pinned to 1 | The gateway terminates WebSockets and hosts GenServer state — it **cannot sleep**. Fly is the only free option tolerating 24/7 + long-lived websockets. BEAM tuning: `ERL_FLAGS=+hmqd off_heap`, capped Finch pool, micro-batched publishes, 32 KB replay-buffer caps. Mix release in slim Alpine; `/healthz` for Fly checks; `/up` for wake-on-paint. Single node → PG2 PubSub, no Redis. |
+| **Agent** | **Render** free web service — **allowed to sleep** after 15 min idle | Always-on would burn ~720 of 750 free instance-hours. Cold start is a designed state: breaker reports `DOWN→HALF_OPEN`, UI shows the "warming up the engines" lights-out animation, wake-on-paint pre-warms, and Oban pings `/internal/health` 90 s before the nightly ingest. Internal auth: long random bearer token in both services' secrets. |
+| **Postgres** | **Supabase** free (500 MB), **not Neon** | The always-on gateway holds persistent connections and Oban polls every second — that burns Neon's ~190 free compute-hours/month in ~8 days (ADR-003). Supabase has no compute-hour meter. Supavisor session mode (or direct IPv6 from Fly); Ecto `pool_size: 5`; `Oban.Notifiers.PG` so nothing depends on LISTEN/NOTIFY through a pooler. The daily Oban cron heartbeat defeats Supabase's 7-day-inactivity pause. Neon fallback documented (aggressive idle disconnect + raised Oban poll interval) but not default. |
+| **Vector store** | **Pinecone** Starter serverless — existing `f1-knowledge` index (aws/us-east-1, the only free region; 1536-dim, text-embedding-3-small) | Namespaces (`static_corpus` / `news`) + deterministic content-hash IDs added at migration so re-ingestion upserts instead of duplicating. `make reindex` rebuilds the entire index from `data/` in one command — the index is cattle, not a pet (Starter indexes have inactivity-deletion precedent). |
+| **Frontend** | **Vercel** free (Hobby) | Static Vite build; env-injected GraphQL HTTPS + WSS URLs at the Fly hostname; `chatformula1.com` via CNAME; **PR preview deploys** as a free recruiter-visible bonus. The landing page renders in <1 s regardless of backend state. |
+| **LLM** | **OpenAI gpt-4o-mini** (generation *and* analysis) behind `providers.py` | gpt-4-turbo was a cost bug for a free demo. Defense in depth: ETS rate limiter → daily USD ledger → SHOWCASE mode → **account-level hard spend cap on the OpenAI billing console**. |
+| **Web search** | **Tavily** free (1000/mo) | Nightly Oban ingest uses ~30/mo; runtime searches bounded by the agent's existing 60/min window. |
+| **Live F1 data** | **Jolpica/Ergast** API (free) | Nightly Oban standings/results sync keeps 2026 data current at zero LLM cost; seeds remain hand-refreshable if the community API lapses. |
+| **Scheduling/uptime** | **GitHub Actions** cron (free on public repos) | Daily wake-ping doubles as an uptime check that opens a GitHub issue on failure — a public health trail. |
+| **Observability** | PromEx `/metrics` + LiveDashboard (API-key gated) + public `systemStats` query | Optional Grafana Cloud free scrape; the frontend pit-wall panel is the primary surface. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,140 @@
+# ChatFormula1 v2 — Migration Roadmap
+
+Companion to [ARCHITECTURE.md](ARCHITECTURE.md). Six phases, each ending **demoable in 5 minutes** — that gate is the scope-creep enforcement mechanism.
+
+---
+
+## Migration Roadmap
+
+Each phase ends **demoable in 5 minutes** — that gate is the scope-creep enforcement mechanism.
+
+### Phase 1 — Slim the engine (Python only, monorepo skeleton)
+**Deliverables:**
+- Repo restructured to `gateway/` (placeholder) + `agent/` + `web/` (placeholder) + `data/` + `docs/`.
+- Dead code deleted in full (see [Repo Hygiene Actions](ROADMAP.md#repo-hygiene-actions)), including **explicit removal of the secret-injecting `ci-cd.yml`** that passed real API keys into unit tests on public PRs — named as a security fix in the migration notes.
+- `graph.py`: missing `import asyncio` fixed (the `both` route currently 500s the most common query path); generation LLM tagged `["generation"]`; ContextScore multi-factor ranking salvaged from `nodes.py` into `rank_context` with dynamic year; graph compiled once at startup; `state.py` trimmed to `AgentState` + `QueryAnalysis`.
+- Stateless `POST /internal/chat` (NDJSON, `astream_events` v2, tag-filtered) + `/internal/health` + bearer auth replacing the public FastAPI surface; per-session MemorySaver dict deleted; history accepted in payload.
+- TavilyClient migrated to `langchain-tavily`; fake `crawl_f1_source`/`map_f1_domain` deleted. `providers.py` factory seam with **gpt-4o-mini** default. Settings decomposed so tests run without API keys (import-time `Settings()` broken).
+- Exact version pins for langgraph/langchain; NDJSON **contract test** asserting the exact event sequence.
+- Fresh path-filtered `agent.yml` CI, **green** (ruff + mypy + pytest, dummy keys only); stale `F1-Slipstream` assertions fixed.
+
+**Demoable:** `curl -N` streams clean typed NDJSON for "who won the last race" — no analysis-JSON leakage; recorded in `docs/STREAMING_PROTOCOL.md`.
+
+### Phase 2 — The gateway exists (Phoenix + Absinthe + Ecto, synchronous chat)
+**Deliverables:**
+- `gateway/` Phoenix 1.7 app with a heavily commented supervision tree; Ecto schemas + migrations + seeds for drivers/constructors/races/results from `data/`.
+- Absinthe schema: Dataloader-batched `drivers`/`races`/`standings`/`nextRace` queries, **complexity + depth limits**, GraphiQL mounted.
+- Conversations + messages persisted in Postgres with `Phoenix.Token` viewer scoping; `sendMessage` as a *synchronous* mutation proxying `/internal/chat` (non-streaming aggregate).
+- ETS token-bucket rate limiter plug + Absinthe middleware + `rateLimitStatus` query; transport-level input validation; Telemetry + LiveDashboard baseline.
+- Deployed: Fly (gateway) + Supabase (Postgres). ExUnit coverage for contexts and resolvers; `gateway.yml` CI green.
+
+**Demoable:** public GraphiQL session — standings query (Dataloader, real F1 data, zero AI), `startConversation`, `sendMessage` round-trip through LangGraph.
+
+### Phase 3 — Lights out: end-to-end streaming (the OTP centerpiece)
+**Deliverables:**
+- `Conversation.Server` GenServers under DynamicSupervisor + Registry: hydration, capped replay buffer, idle timeout/hibernate.
+- StreamRunner under Task.Supervisor consuming agent NDJSON via Req/Finch streaming; `AgentEvent` union published through Absinthe.Subscription with micro-batched `TokenDelta`, per-message topics, subscription-time auth.
+- Circuit breaker GenServer + `systemHealth` query; cache-hit, mid-stream-crash, and **reconnect/replay race** paths handled and integration-tested (tests kill the runner mid-stream); Bypass contract test replaying recorded NDJSON.
+- **Transport spike (week 1):** validate `absinthe_graphql_ws` ↔ Apollo `graphql-ws` on Elixir 1.18/OTP 28 before building UI against it.
+- Agent deployed to Render with bearer-token lockdown.
+
+**Demoable:** GraphiQL subscription pane shows live `TokenDelta` + `NodeTransition` events for a `sendMessage`; docs include the kill-a-GenServer-mid-demo script.
+
+### Phase 4 — The cockpit (React/Apollo frontend, public deploy)
+**Deliverables:**
+- `web/`: Apollo split-link (HttpLink + GraphQLWsLink), codegen-typed hooks, dark carbon-fiber shadcn/ui theme with the disclaimer footer.
+- Streaming chat with idempotent-by-seq reducer, live pipeline-telemetry strip (NodeTransition rendering), citation chips appearing on `SourcesResolved` (before the answer finishes — "the RAG is real" moment), error/warming states with the lights-out animation.
+- **Wake-on-paint** ping wired (first paint → `/up` → gateway warms agent). `nextRace` countdown, standings/calendar/driver pages from pure GraphQL.
+- Deployed end-to-end: Fly + Render + Supabase + Vercel; `chatformula1.com` cut over; PR preview deploys on; `web.yml` CI green. Streamlit's funeral complete.
+
+**Demoable:** the public site streams answers token-by-token while showing which LangGraph node is running.
+
+### Phase 5 — Race operations (Oban, budgets, SHOWCASE, observability)
+**Deliverables:**
+- Oban OSS + Cron live: **nightly Jolpica/Ergast standings sync**, nightly Tavily news ingest (with Render pre-warm ping), daily conversation pruning, title generation, **SHOWCASE cache-warming job**, daily LLM-spend rollup.
+- **SHOWCASE mode ships as a launch blocker:** budget ledger flips `ServiceMode`; cached answers token-replay through the identical publish path with timing histograms and the "replayed from cache" badge; `demoQuestions` chips wired in the UI; demo works with the OpenAI key removed.
+- API keys (`f1s_`/SHA-256/scopes) in Postgres enforcing `triggerIngest` + LiveDashboard; account-level OpenAI spend cap set.
+- PromEx metrics + public `systemStats` rendered as the frontend pit-wall panel; `wake-cron.yml` daily uptime check.
+- Pinecone namespaces + deterministic IDs live via one clean `make reindex`; load test on the 256 MB machine (concurrent streams, replay-buffer memory).
+
+**Demoable:** kill the Python service mid-stream on camera — breaker opens, UI degrades gracefully, other streams unaffected; pull the OpenAI key — SHOWCASE replays convincingly; standings updated themselves overnight.
+
+### Phase 6 — Recruiter packaging and final cut
+**Deliverables:**
+- README rewritten as the 30-second sell: hero GIF of token streaming, one mermaid diagram, **"three files to read"** (`conversations/server.ex`, `schema.ex`, `graph.py`), `make setup/dev/test` quickstart, all-green CI badges, free-tier honesty notes (cold starts, budgets, what SHOWCASE means).
+- `docs/` finalized: ARCHITECTURE (supervision-tree diagram + `:observer` screenshot), STREAMING_PROTOCOL, GRAPHQL, DEPLOYMENT, six ADRs including ADR-000 single-node invariants.
+- Honest framing audit: the README describes exactly what runs — a routed RAG pipeline with LLM-flag routing, not a tool-calling agent; `systemStats` exposes only telemetry-fed numbers.
+- Branding cleanup: every `F1-Slipstream` remnant eradicated; LICENSE + disclaimer audit; 5-minute demo script committed.
+
+**Demoable:** a stranger clones the repo and runs the full stack locally with `docker-compose` + `mix` in under 5 minutes; the repo *is* the portfolio.
+
+---
+
+## Repo Hygiene Actions
+
+### Delete outright (Phase 1 unless noted)
+| Path | Reason |
+|---|---|
+| `src/ui/` (Streamlit app + components) | Replaced by React/Apollo |
+| `tests/test_ui_components.py`, `tests/test_functionality_preservation.py` (~1,540 lines) | Test the deleted UI |
+| `src/agent/nodes.py` (834 lines) | Unwired parallel implementation — salvage ContextScore ranking first |
+| `src/agent/memory.py` | Orphaned; `checkpointer.put` API-incompatible |
+| `src/tools/f1_tools.py` | Tools never bound to any LLM; `predict_race_outcome` contains no LLM call — shipping it misrepresents the architecture |
+| `src/prompts/rag_prompts.py`, `src/prompts/specialized_prompts.py` (~900 lines) | Zero imports outside the package |
+| `state.py`: `SearchDecision`, `PredictionOutput`, `ConversationContext`, `validate_state`, `create_initial_state` | Unused by the running pipeline |
+| `src/utils/free_tier_limiter.py` | Zero imports anywhere — documentation theater |
+| `src/security/request_signing.py` | Test-only; gateway→agent auth uses a bearer token + network posture |
+| `src/security/middleware.py` `InputValidationMiddleware` + `AuthenticationMiddleware` | Never registered; superseded by gateway plugs |
+| `src/api/main.py` background task queue (lines 34–186) | Never called by any route |
+| `src/api/routes/admin.py` dashboards, metrics endpoints, API-key CRUD, `/config*`, `/metrics/reset` | Unauthenticated liability; replaced by PromEx + GraphQL + gateway-enforced keys |
+| `GET /api/chat/sessions` (and the session-API shape generally) | Cross-tenant session enumeration / IDOR — must not be ported |
+| `src/utils/dashboard.py`, `src/utils/metrics.py` collector | Metrics endpoints that no code path feeds |
+| `readme.html` (28 KB marketing mockup) | Not a readme; confusing in a portfolio repo |
+| `setup.py`, `pytest.ini` | Broken shim; duplicate config shadowing pyproject |
+| `.github/workflows/ci.yml`, **`ci-cd.yml`** (injects real API keys into unit tests on public PRs — security fix, named in notes), `deploy.yml`, `render.yaml` | Replaced by path-filtered per-app workflows |
+| `docker-compose.yml` `dev` service (+ obsolete `version:` keys), `docker-compose.prod.yml` | References nonexistent `.devcontainer/Dockerfile` |
+| `scripts/setup_github_actions.sh`, `.github/DEPLOY_GUIDE.md` | Obsolete |
+| `isort` from runtime dependencies; deprecated top-level `[tool.ruff]` config | Toolchain hygiene |
+
+### Move / transform
+| From | To |
+|---|---|
+| `src/agent/graph.py`, trimmed `state.py`, `F1_EXPERT_SYSTEM_PROMPT` | `agent/src/chatf1_agent/` (fixed, tagged, compiled-once) |
+| `src/vector_store/manager.py`, `src/search/tavily_client.py`, `src/utils/cache.py` | `agent/src/chatf1_agent/retrieval/` + `caching.py` |
+| Prompt-injection heuristics from `src/security/input_validation.py` | `agent/src/chatf1_agent/guards.py` (LLM-adjacent); transport-level checks reimplemented in Absinthe input objects |
+| `src/ingestion/*` + CLI | `agent/ingestion/` — deterministic IDs, persisted dedup state, MD5→SHA-256 in `document_processor._hash_document` |
+| `data/drivers.json`, `data/races.json` | Gateway Ecto seeds (structured GraphQL truth); `historical_features.csv` stays agent-side for RAG |
+| Rate limiting / API-key / session / validation / CORS / request-ID semantics | Reimplemented in `gateway/` (behavioral contracts kept: dual windows, 429 + Retry-After, `f1s_` key format, hash-at-rest, scopes) |
+| Existing `Dockerfile` builder/production stages, `Makefile` skeleton, `conftest.py` mock factories | Reused in `agent/` and repo root |
+| Salvageable tests (security, prompts, processor, loader, fallback, graph/vector integration) | `agent/tests/` — `test_config.py` rename assertion fixed; `test_tavily_client.py` rewritten against the new client |
+
+### Docs to rewrite
+- **Rewrite:** `README.md` (hero GIF, three-files-to-read), `ARCHITECTURE.md`, `DEPLOYMENT.md` — all premised on the new topology.
+- **New:** `STREAMING_PROTOCOL.md` (the frozen interface), `GRAPHQL.md`, `docs/adr/` (six ADRs).
+- **Delete/archive:** `GITHUB_ACTIONS.md`, `tests/README.md` (stale paths, wrong counts, nonexistent markers), old `API.md` ("Coming Soon" WebSockets), `OBSERVABILITY.md`/`SECURITY.md` content folded into per-service docs; `TAVILY_INTEGRATION.md` and `SECRETS_MANAGEMENT.md` updated and kept.
+- **Naming:** one pass eradicating `F1-Slipstream` from container names, CI tags, tests, and docs.
+
+---
+
+## Risks & Mitigations
+
+| # | Risk | Mitigation |
+|---|---|---|
+| 1 | **Apollo ↔ Absinthe transport:** `@absinthe/socket` is effectively unmaintained; the plan depends on `absinthe_graphql_ws` speaking standard `graphql-ws`. | Primary choice made decisively (`absinthe_graphql_ws`); validated in a Phase 3 week-1 spike *before* any UI is built. Fallback: raw Phoenix Channels + a thin custom Apollo link. |
+| 2 | **Free-tier cold starts:** Render agent sleeps (~30–60 s); a recruiter hitting the demo cold sees a wait. | Wake-on-paint choreography overlaps the cold start with landing-page reading; `WARMING_UP` events render as polished pit-radio UX (a first-class design pass, not an error path); circuit breaker prevents hangs; `demoQuestions` chips hit pre-warmed SHOWCASE answers and stream instantly regardless. |
+| 3 | **Postgres provider trap:** Neon's ~190 free compute-hours/month die in ~8 days under an always-on Oban-polling gateway. | Supabase chosen (no compute-hour meter); decision frozen in ADR-003 so nobody swaps providers casually; daily Oban heartbeat defeats Supabase's 7-day pause; tuned-Neon fallback documented. |
+| 4 | **Public LLM endpoint = open wallet:** public GraphiQL + a resume URL gets scraped. | Defense in depth, all shipped as Phase 5 launch blockers: ETS rate limiter (per viewer token + IP) → 2000-char input cap → daily USD ledger → SHOWCASE replay (graceful, demoable degradation, never a quota error) → account-level OpenAI billing cap → gpt-4o-mini default. A determined abuser ends the day in SHOWCASE mode — graceful, not broken. |
+| 5 | **BEAM memory on 256 MB Fly:** per-token publishes + replay buffers under concurrent streams. | Micro-batching (40 ms/12 tokens), 32 KB replay-buffer cap per message, `+hmqd off_heap`, capped Finch pool; Phase 5 load test. Worst case: 512 MB tier (~$3/mo) documented as the single permitted constraint break. |
+| 6 | **Fly free-allowance drift** (new orgs get trial credits, not perpetual free). | Verify current pricing before Phase 2 deploy and record in DEPLOYMENT.md; design is host-portable — the wake/warming UX already tolerates Render's spin-down, so the gateway can fall back to a Render service with the bearer token becoming load-bearing. |
+| 7 | **LangGraph/LangChain version churn** (already biting: deprecated TavilySearchResults, legacy `astream_events` v1, broken checkpointer signature in dead code). | Phase 1: exact pins, `astream_events` v2 migration, `langchain-tavily`; the NDJSON protocol is the frozen interface with contract tests on **both** sides, so upstream bumps fail loudly at CI, not silently in the gateway stream. |
+| 8 | **Reconnect double-delivery:** replay-buffer + live-publish overlap can duplicate `TokenDelta`s. | Seq numbers + idempotent-by-seq frontend reducer + an explicit subscription integration test for the reconnect race. Scope valve: if Phase 3 slips, cut replay to refetch-on-reconnect (final message always in Postgres). |
+| 9 | **Pinecone Starter fragility:** single free region, inactivity-deletion precedent, random-ID duplication on re-ingest. | Deterministic content-hash IDs + namespaces land *before* any re-ingestion; `make reindex` rebuilds the whole index from `data/` in one command — the vector store is cattle, not a pet. |
+| 10 | **Single-node invariants silently break at node #2:** ETS limiter, local PubSub fan-out, replay buffers, in-proc Python caches, `Oban.Notifiers.PG`. | ADR-000 documents every invariant; machine count pinned to 1 in `fly.toml`; revisiting it is an explicit, written decision. |
+| 11 | **Scope creep — the portfolio killer:** the dead v1 code (tool layer, dashboards, key CRUD, request signing) was all plausible-looking ambition that rotted. | Each phase's "demoable in 5 minutes" gate is the enforcement mechanism; no clustering, Redis, multi-region, auth/users, or tool-calling-agent rewrite — anything off the showcase inventory (ARCHITECTURE.md §5) is cut by default. |
+| 12 | **Honesty/credibility debt inherited from v1:** metrics that lied, an "agent" that is a routed RAG pipeline. | README states exactly what runs; `systemStats` exposes only telemetry-fed numbers; SHOWCASE replays carry a visible "replayed from cache" badge; Phase 6 includes an explicit honest-framing audit. A code-reading reviewer who finds theater loses all trust — so there is none. |
+| 13 | **CI baseline is red today** (435 ruff issues, stale tests, `ENVIRONMENT='test'` rejected by Settings, secret-injecting workflow). | Phase 1 builds green from scratch — no workflow is ported; import-time `Settings()` is broken apart first; dummy keys only in CI, forever; toolchain pins unified (ruff/black/mypy across pyproject, pre-commit, CI). |
+| 14 | **Jolpica/Ergast is a community API that could lapse.** | Standings sync degrades gracefully (last-synced timestamp surfaced in `systemStats`); seeds remain hand-refreshable; the structured-data showcase never depends on the sync succeeding on any given night. |
+
+---
+
+*Build order is fixed. Two non-negotiable launch blockers: the replay buffer ships capped with a tested idempotent reducer (or is cut to refetch-on-reconnect), and SHOWCASE mode ships before the URL goes on a resume.*


### PR DESCRIPTION
## Summary

Phase 0 of the v2 conversion: lands the architecture blueprint and migration roadmap that every subsequent PR will execute against.

- **`docs/ARCHITECTURE.md`** (rewritten) — service boundary (Elixir gateway IS the application; Python is a stateless inference engine; React is a rendering surface), full Absinthe GraphQL SDL, end-to-end token streaming design (LangGraph NDJSON → GenServer fan-out → Absinthe subscriptions → Apollo), OTP showcase inventory, monorepo layout, and the $0/month free-tier hosting topology (Fly + Render + Supabase + Pinecone + Vercel).
- **`docs/ROADMAP.md`** (new) — six migration phases, each gated on "demoable in 5 minutes", plus repo hygiene actions (dead-code deletion list, moves, doc rewrites) and a 14-item risk register with mitigations.

## Context

The repo's current state (`main`, archived as `legacy/v1-python`) is the Python/Streamlit v1. v2 converts this into a portfolio demo proving Elixir + GraphQL + AI competence together — AI deliberately not the only star.

## Next

Phase 1 (separate PR): monorepo restructure + slimming the Python agent to a stateless internal NDJSON streaming service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)