### PR TITLE
Phase 5a: model-agnostic provider layer — OpenAI + Ollama first-class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 	setup-agent dev-agent test-agent lint-agent \
 	setup-gateway dev-gateway test-gateway lint-gateway \
 	setup-web dev-web test-web lint-web codegen-web \
-	db ingest clean
+	db ingest reindex clean
 
 help:
 	@echo "ChatFormula1 monorepo targets:"
@@ -16,6 +16,8 @@ help:
 	@echo "  make lint     Run all linters"
 	@echo "  make db       Start the local Postgres container only"
 	@echo "  make ingest   Run the agent ingestion pipeline over data/"
+	@echo "  make reindex  Delete + recreate the Pinecone index (run BEFORE"
+	@echo "                re-ingesting after any embedding model/dimension change)"
 	@echo "  make clean    Remove caches and build artifacts"
 	@echo ""
 	@echo "Per-app targets: <verb>-agent, <verb>-gateway, <verb>-web"
@@ -83,6 +85,12 @@ db:
 
 ingest:
 	cd agent && poetry run f1-ingest --data-dir ../data ingest-all
+
+# Destroys and recreates the Pinecone index with the configured embedding
+# dimension. Required whenever the embedding provider/model/dimension
+# changes — ALWAYS reindex before re-ingesting, never after.
+reindex:
+	cd agent && poetry run f1-ingest --data-dir ../data reindex
 
 clean:
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ChatFormula1 answers Formula 1 questions through a routed RAG pipeline:
 ### Agent (implemented — Phase 1)
 - **[Python 3.12](https://www.python.org/)** + **[FastAPI](https://fastapi.tiangolo.com/)** — internal-only NDJSON streaming API
 - **[LangGraph](https://langchain-ai.github.io/langgraph/)** / **[LangChain](https://python.langchain.com/)** — pipeline orchestration (exact-pinned)
-- **[OpenAI gpt-4o-mini](https://platform.openai.com/)** — generation and analysis, behind a provider seam
+- **Model-agnostic LLMs** — [OpenAI](https://platform.openai.com/) gpt-4o-mini by default, [Ollama](https://ollama.com/) (local or cloud) or any OpenAI-compatible endpoint via a 4-line env change ([ADR-002](docs/adr/002-model-agnostic-providers.md))
 - **[Pinecone](https://www.pinecone.io/)** — vector search (`static_corpus` / `news` namespaces, deterministic SHA-256 IDs)
 - **[Tavily](https://tavily.com/)** — real-time web search via `langchain-tavily`
 

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,24 +1,56 @@
 # ChatFormula1 agent service — environment configuration
 # Copy to .env and fill in real values. Every variable maps to a field in
-# src/chatf1_agent/settings.py.
+# src/chatf1_agent/settings.py; provider resolution rules live in
+# src/chatf1_agent/providers.py.
 
-# --- Credentials (required to run the service; tests use dummies) ---
-OPENAI_API_KEY=your_openai_api_key_here
+# --- Credentials (tests run with dummies; never commit real values) ---
 PINECONE_API_KEY=your_pinecone_api_key_here
 TAVILY_API_KEY=your_tavily_api_key_here
 
 # Static bearer token shared with the gateway (generate a long random value)
 INTERNAL_API_TOKEN=your_internal_api_token_here
 
-# --- LLM (defaults shown) ---
-# GENERATION_MODEL=gpt-4o-mini
-# ANALYSIS_MODEL=gpt-4o-mini
-# OPENAI_TEMPERATURE=0.7
-# OPENAI_MAX_TOKENS=1000
+# ============================================================================
+# LLM provider — the agent speaks the OpenAI wire protocol to every provider.
+# Uncomment exactly ONE block. If you change the embedding model/provider,
+# you MUST set EMBEDDING_DIMENSION and rebuild the index (`make reindex`)
+# BEFORE re-ingesting — vectors from different models are not interchangeable.
+# ============================================================================
+
+# --- Provider block 1: OpenAI (default) ---
+OPENAI_API_KEY=your_openai_api_key_here
+# LLM_PROVIDER=openai
+# LLM_MODEL=gpt-4o-mini
+# LLM_ANALYSIS_MODEL=                      # empty = same as LLM_MODEL
+# LLM_SUPPORTS_FUNCTION_CALLING=true       # provider default for openai
+# EMBEDDING_MODEL=text-embedding-3-small
+# EMBEDDING_DIMENSION=1536                 # implied default for openai
+
+# --- Provider block 2: Ollama local (no API keys at all) ---
+# LLM_PROVIDER=ollama
+# LLM_MODEL=qwen3:8b
+# LLM_BASE_URL=http://localhost:11434/v1   # provider default; override if remote
+# LLM_SUPPORTS_FUNCTION_CALLING=false      # provider default; true for tool-capable models
+# EMBEDDING_MODEL=nomic-embed-text         # 768 dims; mxbai-embed-large = 1024
+# EMBEDDING_DIMENSION=768                  # REQUIRED for non-OpenAI providers
+
+# --- Provider block 3: Ollama Cloud (big models, no local GPU) ---
+# LLM_PROVIDER=ollama
+# LLM_BASE_URL=https://ollama.com/v1
+# LLM_API_KEY=your_ollama_cloud_api_key
+# LLM_MODEL=gpt-oss:120b
+# Ollama Cloud hosts chat models, not embedding models — either run
+# embeddings on a local Ollama or keep them on OpenAI:
+# EMBEDDING_PROVIDER=openai
+# EMBEDDING_MODEL=text-embedding-3-small
+# EMBEDDING_DIMENSION=1536
+
+# --- Generation tuning (provider-independent defaults shown) ---
+# LLM_TEMPERATURE=0.7
+# LLM_MAX_TOKENS=1000
 
 # --- Pinecone (defaults shown) ---
 # PINECONE_INDEX_NAME=f1-knowledge
-# PINECONE_DIMENSION=1536
 
 # --- Tavily (defaults shown) ---
 # TAVILY_MAX_RESULTS=5

--- a/agent/README.md
+++ b/agent/README.md
@@ -14,15 +14,16 @@ analyze_query → route → (vector_search | tavily_search | parallel_retrieval)
               → rank_context → generate → format_response
 ```
 
-- **Query analysis** — structured-output intent + entity extraction
-  (gpt-4o-mini, temperature 0)
+- **Query analysis** — intent + entity extraction at temperature 0, via
+  function-calling structured output or a prompted-JSON fallback depending
+  on the provider (see [Model providers](#model-providers))
 - **Retrieval** — Pinecone semantic search (`f1-knowledge` index, namespaces
   `static_corpus` / `news`) and/or Tavily web search, in parallel when both
   are needed
 - **Ranking** — multi-factor scoring (relevance 40%, recency 30%,
   authority 20%, completeness 10%)
-- **Generation** — gpt-4o-mini tagged `generation`; only its tokens are
-  forwarded on the stream
+- **Generation** — the configured chat model (default gpt-4o-mini) tagged
+  `generation`; only its tokens are forwarded on the stream
 
 Responses stream as NDJSON events — the frozen contract between this service
 and the gateway, documented in
@@ -36,6 +37,55 @@ contract tests (`tests/test_streaming_contract.py`).
 | `POST /internal/chat` | NDJSON streaming chat. Body: `{message, history, request_id}`. Stateless — history arrives in the payload. |
 | `POST /internal/ingest` | Trigger an ingestion run (`{"source": "static"}` or `{"source": "news"}`). |
 | `GET /internal/health` | Liveness probe; doubles as the cold-start pre-warm target. |
+
+## Model providers
+
+The agent is model-agnostic: both chat models and the embedding client are
+built exclusively by the provider factory
+(`src/chatf1_agent/providers.py`), which speaks the OpenAI wire protocol to
+OpenAI, Ollama (local or cloud), and any other OpenAI-compatible server
+(vLLM, LM Studio, OpenRouter). Full reasoning:
+[ADR-002](../docs/adr/002-model-agnostic-providers.md).
+
+OpenAI is the default. Switching to local Ollama is four lines of env:
+
+```bash
+LLM_PROVIDER=ollama              # endpoint defaults to http://localhost:11434/v1
+LLM_MODEL=qwen3:8b
+EMBEDDING_MODEL=nomic-embed-text
+EMBEDDING_DIMENSION=768          # the index dimension travels with the model
+```
+
+> **⚠️ Changing the embedding provider/model changes the vector space.**
+> Vectors from different models are not interchangeable, so the Pinecone
+> index must be rebuilt: `make reindex` (delete + recreate, destroys all
+> vectors), **then** `make ingest`. The agent validates the live index
+> dimension at startup and refuses to run against a mismatch. Always
+> reindex *before* re-ingesting — never after.
+
+Ollama Cloud serves big open models over the same protocol — set
+`LLM_BASE_URL=https://ollama.com/v1` and `LLM_API_KEY` (see
+`.env.example`, provider block 3). Honest tradeoffs:
+
+| | OpenAI | Ollama local | Ollama Cloud |
+|---|---|---|---|
+| Cost | per-token | free (your hardware) | free tier with rate/usage limits, then paid |
+| Latency | consistent | cold model loads on first request (seconds-tens of seconds) | shared infra; cold loads possible |
+| Function calling | reliable | model-dependent, often unreliable → JSON fallback | model-dependent |
+| Embeddings | text-embedding-3-small (1536) | nomic-embed-text 768 / mxbai-embed-large 1024 | chat-only catalog — run embeddings locally or keep OpenAI (`EMBEDDING_PROVIDER=openai`) |
+
+**Structured output**: `llm_supports_function_calling` (default true only
+for `openai`) selects the analysis strategy. When false, the analysis
+prompt embeds the `QueryAnalysis` JSON Schema and the reply is parsed with
+Pydantic — one repair retry with the validation error appended, then a
+safe default that retrieves from both sources. Either way the analysis
+model is untagged, so its output never reaches the NDJSON token stream.
+
+Check the effective configuration any time:
+
+```bash
+poetry run f1-ingest --data-dir ../data check-config
+```
 
 ## Security
 

--- a/agent/ingestion/cli.py
+++ b/agent/ingestion/cli.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sys
+import time
 
 import click
 import structlog
@@ -315,12 +316,31 @@ def check_config(ctx: click.Context) -> None:
             click.echo("✅ Configuration loaded successfully")
             click.echo(f"  Environment: {config.environment}")
             click.echo(f"  Log level: {config.log_level}")
-            click.echo(f"  Pinecone index: {config.pinecone_index_name}")
+
+            click.echo("\n🤖 LLM provider")
+            click.echo(f"  Provider: {config.llm_provider}")
+            click.echo(f"  Base URL: {config.llm_base_url or '(provider default)'}")
             click.echo(f"  Generation model: {config.llm_model}")
+            click.echo(f"  Analysis model: {config.analysis_model}")
+            click.echo(f"  Function calling: {config.supports_function_calling}")
+
+            click.echo("\n🧬 Embeddings")
+            click.echo(f"  Provider: {config.resolved_embedding_provider}")
+            click.echo(
+                f"  Base URL: {config.embedding_base_url or '(provider default)'}"
+            )
+            click.echo(f"  Model: {config.embedding_model}")
+            # Raises with remediation when the dimension is unresolvable.
+            expected_dimension = config.resolved_embedding_dimension
+            click.echo(f"  Dimension: {expected_dimension}")
+
+            click.echo("\n📚 Ingestion")
+            click.echo(f"  Pinecone index: {config.pinecone_index_name}")
             click.echo(f"  Chunk size: {config.chunk_size}")
             click.echo(f"  Chunk overlap: {config.chunk_overlap}")
 
-            # Test vector store connection
+            # Test vector store connection (validates the index dimension
+            # against the configured embeddings and fails loudly on drift).
             click.echo("\n🔌 Testing vector store connection...")
             data_dir = ctx.obj["data_dir"]
             pipeline = IngestionPipeline(config=config, data_dir=data_dir)
@@ -332,7 +352,10 @@ def check_config(ctx: click.Context) -> None:
             if health["status"] == "healthy":
                 click.echo("✅ Vector store connection successful")
                 click.echo(f"  Index: {health['index_name']}")
-                click.echo(f"  Dimension: {health['dimension']}")
+                click.echo(
+                    f"  Dimension: {health['dimension']} "
+                    f"(matches configured {expected_dimension} ✅)"
+                )
                 click.echo(f"  Vectors: {health['total_vector_count']}")
             else:
                 click.echo(
@@ -349,6 +372,81 @@ def check_config(ctx: click.Context) -> None:
 
     # Run async function
     asyncio.run(run_check())
+
+
+@cli.command()
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip the confirmation prompt (CI / scripted use).",
+)
+def reindex(yes: bool) -> None:
+    """Delete and recreate the Pinecone index (destroys ALL vectors).
+
+    Run this BEFORE re-ingesting whenever the embedding provider, model,
+    or dimension changes — vectors from different embedding models are
+    not interchangeable. Repopulate afterwards with `make ingest`.
+    """
+    from pinecone import Pinecone, ServerlessSpec
+
+    click.echo("🏎️  ChatFormula1 Index Rebuild")
+    click.echo("=" * 50)
+
+    try:
+        config = get_settings()
+        config.require("pinecone_api_key")
+        dimension = config.resolved_embedding_dimension
+        name = config.pinecone_index_name
+
+        click.echo(f"Index: {name}")
+        click.echo(f"Embedding provider: {config.resolved_embedding_provider}")
+        click.echo(f"Embedding model: {config.embedding_model}")
+        click.echo(f"Dimension: {dimension}")
+
+        pc = Pinecone(api_key=config.pinecone_api_key)
+        existing = [idx.name for idx in pc.list_indexes()]
+
+        if name in existing:
+            stats = pc.Index(name).describe_index_stats()
+            count = stats.total_vector_count
+            if not yes:
+                click.confirm(
+                    f"\n⚠️  Delete index '{name}' ({count} vectors)? "
+                    "This cannot be undone",
+                    abort=True,
+                )
+            click.echo(f"🗑️  Deleting index '{name}'...")
+            pc.delete_index(name)
+
+            # Deletion is asynchronous server-side; wait until it is gone.
+            deadline = time.monotonic() + 60
+            while name in [idx.name for idx in pc.list_indexes()]:
+                if time.monotonic() > deadline:
+                    raise TimeoutError(
+                        f"Index '{name}' was not deleted within 60s; "
+                        "retry once Pinecone finishes the deletion."
+                    )
+                time.sleep(2)
+        else:
+            click.echo(f"Index '{name}' does not exist yet; creating it fresh.")
+
+        click.echo(f"🆕 Creating index '{name}' ({dimension}-dim, cosine)...")
+        pc.create_index(
+            name=name,
+            dimension=dimension,
+            metric="cosine",
+            spec=ServerlessSpec(cloud="aws", region="us-east-1"),
+        )
+
+        click.echo("\n✅ Index rebuilt and EMPTY. Re-ingest with: make ingest")
+        logger.info("reindex_complete", index_name=name, dimension=dimension)
+
+    except click.Abort:
+        raise
+    except Exception as e:
+        click.echo(f"\n❌ Reindex failed: {e}", err=True)
+        logger.error("reindex_failed", error=str(e))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/agent/ingestion/cli.py
+++ b/agent/ingestion/cli.py
@@ -316,7 +316,7 @@ def check_config(ctx: click.Context) -> None:
             click.echo(f"  Environment: {config.environment}")
             click.echo(f"  Log level: {config.log_level}")
             click.echo(f"  Pinecone index: {config.pinecone_index_name}")
-            click.echo(f"  Generation model: {config.generation_model}")
+            click.echo(f"  Generation model: {config.llm_model}")
             click.echo(f"  Chunk size: {config.chunk_size}")
             click.echo(f"  Chunk overlap: {config.chunk_overlap}")
 

--- a/agent/src/chatf1_agent/graph.py
+++ b/agent/src/chatf1_agent/graph.py
@@ -7,6 +7,7 @@ server can forward only its tokens to clients.
 """
 
 import asyncio
+import json
 import time
 from datetime import datetime
 from typing import Any, Literal, cast
@@ -16,7 +17,7 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, System
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import Runnable
 from langgraph.graph import END, StateGraph
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from chatf1_agent.caching import get_cache_manager
 from chatf1_agent.prompts import F1_EXPERT_SYSTEM_PROMPT
@@ -30,6 +31,54 @@ logger = structlog.get_logger(__name__)
 
 # Domains whose results get an authority boost during ranking.
 TRUSTED_DOMAINS = ["formula1.com", "fia.com", "autosport.com"]
+
+ANALYSIS_SYSTEM_PROMPT = """You are a query analyzer for an F1 chatbot. Analyze the user's query and extract:
+1. Intent: current_info, historical, prediction, technical, general, or off_topic
+2. Confidence: 0.0 to 1.0
+3. Whether real-time search is needed
+4. Whether vector store search is needed
+5. Entities: drivers, teams, races, years, circuits
+6. Time period if relevant
+7. Brief reasoning
+
+Be accurate and concise."""
+
+
+def safe_default_analysis(reason: str) -> QueryAnalysis:
+    """Conservative analysis used when the model's output is unusable.
+
+    Routes to BOTH retrieval sources: over-retrieving costs a little
+    latency, under-retrieving costs answer quality.
+
+    Args:
+        reason: Human-readable explanation recorded in the analysis.
+
+    Returns:
+        A QueryAnalysis that retrieves from the vector store and the web.
+    """
+    return QueryAnalysis(
+        intent="general",
+        confidence=0.0,
+        requires_search=True,
+        requires_vector_search=True,
+        entities={},
+        time_period=None,
+        reasoning=reason,
+    )
+
+
+def _extract_json(text: str) -> str:
+    """Pull the JSON object out of a model reply.
+
+    Tolerates markdown fences and surrounding prose by slicing from the
+    first ``{`` to the last ``}``. Anything else is returned as-is and
+    left for Pydantic to reject.
+    """
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        return text[start : end + 1]
+    return text.strip()
 
 
 class ContextScore(BaseModel):
@@ -192,7 +241,11 @@ class F1AgentGraph:
     async def analyze_query_node(self, state: AgentState) -> dict[str, Any]:
         """Analyze the user query to detect intent and extract entities.
 
-        Uses structured output to ensure a consistent analysis format.
+        Two provider-dependent paths produce the same QueryAnalysis:
+        function-calling structured output when the model supports it,
+        otherwise a prompted-JSON path with one repair retry and a safe
+        route-to-both default. Neither path is tagged ``generation``, so
+        analysis output never reaches the user-visible token stream.
 
         Args:
             state: Current agent state
@@ -204,30 +257,14 @@ class F1AgentGraph:
 
         logger.info("analyzing_query", query=query[:100])
 
-        analysis_prompt = ChatPromptTemplate.from_messages(
-            [
-                SystemMessage(
-                    content="""You are a query analyzer for an F1 chatbot. Analyze the user's query and extract:
-1. Intent: current_info, historical, prediction, technical, general, or off_topic
-2. Confidence: 0.0 to 1.0
-3. Whether real-time search is needed
-4. Whether vector store search is needed
-5. Entities: drivers, teams, races, years, circuits
-6. Time period if relevant
-7. Brief reasoning
-
-Be accurate and concise."""
-                ),
-                HumanMessage(content=f"Analyze this F1 query: {query}"),
-            ]
-        )
-
         try:
-            structured_llm = self.analysis_llm.with_structured_output(QueryAnalysis)
-            analysis = cast(
-                QueryAnalysis,
-                await structured_llm.ainvoke(analysis_prompt.format_messages()),
-            )
+            used_fallback = False
+            if self.config.supports_function_calling:
+                mode = "function_calling"
+                analysis = await self._analyze_with_function_calling(query)
+            else:
+                mode = "json"
+                analysis, used_fallback = await self._analyze_with_json_prompt(query)
 
             logger.info(
                 "query_analyzed",
@@ -235,16 +272,22 @@ Be accurate and concise."""
                 confidence=analysis.confidence,
                 requires_search=analysis.requires_search,
                 requires_vector=analysis.requires_vector_search,
+                analysis_mode=mode,
             )
+
+            metadata: dict[str, Any] = {
+                "analysis": analysis.model_dump(),
+                "analysis_mode": mode,
+                "requires_search": analysis.requires_search,
+                "requires_vector_search": analysis.requires_vector_search,
+            }
+            if used_fallback:
+                metadata["analysis_fallback"] = True
 
             return {
                 "intent": analysis.intent,
                 "entities": analysis.entities,
-                "metadata": {
-                    "analysis": analysis.model_dump(),
-                    "requires_search": analysis.requires_search,
-                    "requires_vector_search": analysis.requires_vector_search,
-                },
+                "metadata": metadata,
             }
 
         except Exception as e:
@@ -259,6 +302,93 @@ Be accurate and concise."""
                     "requires_vector_search": True,
                 },
             }
+
+    async def _analyze_with_function_calling(self, query: str) -> QueryAnalysis:
+        """Analyze via function-calling structured output (OpenAI-class models).
+
+        Args:
+            query: User query to analyze.
+
+        Returns:
+            Parsed QueryAnalysis from the model's tool call.
+        """
+        analysis_prompt = ChatPromptTemplate.from_messages(
+            [
+                SystemMessage(content=ANALYSIS_SYSTEM_PROMPT),
+                HumanMessage(content=f"Analyze this F1 query: {query}"),
+            ]
+        )
+        structured_llm = self.analysis_llm.with_structured_output(QueryAnalysis)
+        return cast(
+            QueryAnalysis,
+            await structured_llm.ainvoke(analysis_prompt.format_messages()),
+        )
+
+    async def _analyze_with_json_prompt(self, query: str) -> tuple[QueryAnalysis, bool]:
+        """Analyze via prompted JSON for models without function calling.
+
+        The prompt embeds the QueryAnalysis JSON Schema and demands a bare
+        JSON object. On a parse failure the model gets exactly ONE repair
+        attempt with the validation error appended; if that also fails the
+        node returns the safe default (retrieve from both sources) instead
+        of failing the request.
+
+        Args:
+            query: User query to analyze.
+
+        Returns:
+            ``(analysis, used_safe_default)``.
+        """
+        schema = json.dumps(QueryAnalysis.model_json_schema(), separators=(",", ":"))
+        messages: list[BaseMessage] = [
+            SystemMessage(
+                content=(
+                    ANALYSIS_SYSTEM_PROMPT
+                    + "\n\nRespond with a single JSON object that validates "
+                    "against this JSON Schema. No prose, no markdown fences, "
+                    "JSON only:\n" + schema
+                )
+            ),
+            HumanMessage(content=f"Analyze this F1 query: {query}"),
+        ]
+
+        reply = await self.analysis_llm.ainvoke(messages)
+        raw = str(reply.content)
+        try:
+            return QueryAnalysis.model_validate_json(_extract_json(raw)), False
+        except ValidationError as parse_error:
+            logger.warning(
+                "analysis_json_invalid_retrying", error=str(parse_error)[:500]
+            )
+            retry_messages: list[BaseMessage] = [
+                *messages,
+                AIMessage(content=raw),
+                HumanMessage(
+                    content=(
+                        "Your previous reply was not a valid JSON object for "
+                        f"the schema. Validation error:\n{parse_error}\n"
+                        "Reply again with ONLY the corrected JSON object."
+                    )
+                ),
+            ]
+            retry_reply = await self.analysis_llm.ainvoke(retry_messages)
+            try:
+                analysis = QueryAnalysis.model_validate_json(
+                    _extract_json(str(retry_reply.content))
+                )
+                return analysis, False
+            except ValidationError as retry_error:
+                logger.error(
+                    "analysis_json_invalid_after_retry",
+                    error=str(retry_error)[:500],
+                )
+                return (
+                    safe_default_analysis(
+                        "Query analysis produced unparseable JSON twice; "
+                        "defaulting to retrieval from both sources."
+                    ),
+                    True,
+                )
 
     async def route_node(self, state: AgentState) -> dict[str, Any]:
         """Record the routing decision based on query analysis.

--- a/agent/src/chatf1_agent/graph.py
+++ b/agent/src/chatf1_agent/graph.py
@@ -138,9 +138,13 @@ class F1AgentGraph:
 
         logger.info(
             "f1_agent_graph_initialized",
-            generation_model=config.generation_model,
+            provider=config.llm_provider,
+            generation_model=config.llm_model,
             analysis_model=config.analysis_model,
-            temperature=config.openai_temperature,
+            temperature=config.llm_temperature,
+            structured_output=(
+                "function_calling" if config.supports_function_calling else "json"
+            ),
         )
 
     def _build_graph(self) -> StateGraph:
@@ -613,8 +617,8 @@ Be accurate and concise."""
         cache_key = cache_manager.get_llm_cache_key(
             query=query,
             context=context,
-            model=self.config.generation_model,
-            temperature=self.config.openai_temperature,
+            model=self.config.llm_model,
+            temperature=self.config.llm_temperature,
         )
 
         cached_response = cache_manager.llm_cache.get(cache_key)

--- a/agent/src/chatf1_agent/providers.py
+++ b/agent/src/chatf1_agent/providers.py
@@ -1,36 +1,144 @@
-"""LLM factory seam.
+"""Model-agnostic chat and embedding factory.
 
-Both the generation and analysis models default to gpt-4o-mini and are
-configured exclusively through :class:`~chatf1_agent.settings.Settings`,
-so swapping providers or models is a one-line settings change.
+This module is the single seam between the agent and whatever serves its
+models. Three decisions shape it:
 
-The generation model is tagged ``["generation"]`` — the streaming server
-forwards ``on_chat_model_stream`` events only for that tag, which keeps the
-analysis model's structured-output JSON out of the user-visible stream.
+1. **One wire protocol, many providers.** Every provider this app targets —
+   OpenAI, Ollama (local or cloud), vLLM, LM Studio, OpenRouter — speaks the
+   OpenAI chat/embeddings API. So instead of one integration package per
+   vendor, the factory always builds ``langchain-openai`` clients and varies
+   only ``base_url``, ``api_key``, and capability flags. Switching providers
+   is a settings change, never a code change.
+
+2. **Capabilities are configuration, not model-name heuristics.**
+   ``Settings.supports_function_calling`` tells the graph whether the model
+   can honor ``with_structured_output``; when it can't (most local models),
+   the graph drops to a prompted-JSON analysis path. The factory never
+   branches on model names.
+
+3. **The embedding dimension travels with the provider.** Embeddings from
+   different models are not interchangeable, so ``create_embeddings``
+   resolves the dimension eagerly — a provider switch without an explicit
+   ``embedding_dimension`` fails at construction, not at query time.
+
+Both chat models (generation + analysis) and the embedding client MUST be
+built here. The generation model is tagged ``["generation"]`` — the
+streaming server forwards ``on_chat_model_stream`` events only for that
+tag, which keeps the analysis model's output off the user-visible stream.
+Constructing a model anywhere else would bypass that contract.
 """
 
-from langchain_openai import ChatOpenAI
+from typing import Any
+
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
 from chatf1_agent.settings import Settings
 
 GENERATION_TAG = "generation"
 
+# Ollama's OpenAI-compatible endpoints. The local URL is applied
+# automatically for `llm_provider=ollama`; Ollama Cloud is opt-in via
+# LLM_BASE_URL because it needs an API key and hosts a different catalog.
+OLLAMA_LOCAL_BASE_URL = "http://localhost:11434/v1"
+OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 
-def create_generation_llm(settings: Settings) -> ChatOpenAI:
-    """Create the streaming LLM used for answer generation.
+# OpenAI client libraries refuse to start without *some* API key, but local
+# servers (Ollama, LM Studio, vLLM) never check it. Convention is "ollama".
+DUMMY_API_KEY = "ollama"
+
+# Batch size for embedding requests (matches the OpenAI API sweet spot and
+# is harmless for local servers, which just see smaller payloads).
+EMBEDDING_BATCH_SIZE = 100
+
+
+def _resolve_endpoint(
+    provider: str,
+    base_url: str | None,
+    api_key: str,
+    settings: Settings,
+    base_url_setting: str,
+) -> tuple[str | None, str]:
+    """Resolve (base_url, api_key) for one OpenAI-compatible endpoint.
 
     Args:
-        settings: Application settings (model name, temperature, limits).
+        provider: One of ``openai``, ``ollama``, ``openai_compatible``.
+        base_url: Explicit endpoint override, if any.
+        api_key: Explicit key for non-OpenAI providers, if any.
+        settings: Application settings (for the OpenAI credential check).
+        base_url_setting: Settings field name to cite in error messages.
 
     Returns:
-        A streaming ChatOpenAI instance tagged ``["generation"]``.
+        ``(base_url, api_key)`` ready to hand to a langchain-openai client.
+        ``base_url=None`` means the client's default (api.openai.com).
+
+    Raises:
+        ValueError: If credentials or a required base URL are missing.
     """
-    settings.require("openai_api_key")
+    if provider == "openai":
+        settings.require("openai_api_key")
+        return base_url, settings.openai_api_key
+
+    if provider == "ollama":
+        return base_url or OLLAMA_LOCAL_BASE_URL, api_key or DUMMY_API_KEY
+
+    # openai_compatible: there is no sane default endpoint to guess.
+    if not base_url:
+        raise ValueError(
+            f"{base_url_setting} must be set when the provider is "
+            "'openai_compatible' — there is no default endpoint to assume. "
+            "Point it at your server's OpenAI-compatible /v1 root."
+        )
+    return base_url, api_key or DUMMY_API_KEY
+
+
+def resolve_chat_endpoint(settings: Settings) -> tuple[str | None, str]:
+    """Resolve the chat-model endpoint from settings."""
+    return _resolve_endpoint(
+        provider=settings.llm_provider,
+        base_url=settings.llm_base_url,
+        api_key=settings.llm_api_key,
+        settings=settings,
+        base_url_setting="llm_base_url",
+    )
+
+
+def resolve_embedding_endpoint(settings: Settings) -> tuple[str | None, str]:
+    """Resolve the embedding endpoint from settings.
+
+    When ``embedding_provider`` is unset, embeddings follow the chat
+    endpoint entirely (provider, base URL, and key); explicit embedding
+    settings always win.
+    """
+    base_url = settings.embedding_base_url
+    api_key = settings.embedding_api_key
+    if settings.embedding_provider is None:
+        base_url = base_url or settings.llm_base_url
+        api_key = api_key or settings.llm_api_key
+    return _resolve_endpoint(
+        provider=settings.resolved_embedding_provider,
+        base_url=base_url,
+        api_key=api_key,
+        settings=settings,
+        base_url_setting="embedding_base_url",
+    )
+
+
+def create_generation_llm(settings: Settings) -> ChatOpenAI:
+    """Create the streaming chat model used for answer generation.
+
+    Args:
+        settings: Application settings (provider, model, temperature, limits).
+
+    Returns:
+        A streaming chat model tagged ``["generation"]`` for stream filtering.
+    """
+    base_url, api_key = resolve_chat_endpoint(settings)
     return ChatOpenAI(
-        api_key=settings.openai_api_key,
-        model=settings.generation_model,
-        temperature=settings.openai_temperature,
-        max_tokens=settings.openai_max_tokens,
+        api_key=api_key,
+        base_url=base_url,
+        model=settings.llm_model,
+        temperature=settings.llm_temperature,
+        max_tokens=settings.llm_max_tokens,
         streaming=True,
         stream_usage=True,
         timeout=30,
@@ -39,18 +147,63 @@ def create_generation_llm(settings: Settings) -> ChatOpenAI:
 
 
 def create_analysis_llm(settings: Settings) -> ChatOpenAI:
-    """Create the deterministic LLM used for structured query analysis.
+    """Create the deterministic chat model used for query analysis.
+
+    Deliberately untagged: its output (function-calling or prompted JSON)
+    must never reach the user-visible token stream.
 
     Args:
-        settings: Application settings (model name).
+        settings: Application settings (provider, analysis model).
 
     Returns:
-        A temperature-0 ChatOpenAI instance for structured output.
+        A temperature-0 chat model for structured or JSON-mode analysis.
     """
-    settings.require("openai_api_key")
+    base_url, api_key = resolve_chat_endpoint(settings)
     return ChatOpenAI(
-        api_key=settings.openai_api_key,
+        api_key=api_key,
+        base_url=base_url,
         model=settings.analysis_model,
         temperature=0.0,
         timeout=30,
     )
+
+
+def create_embeddings(settings: Settings) -> OpenAIEmbeddings:
+    """Create the embedding client for the configured provider.
+
+    Resolves the embedding dimension eagerly so a misconfigured provider
+    switch fails here, loudly, instead of corrupting the vector index.
+
+    Args:
+        settings: Application settings (embedding provider, model, dimension).
+
+    Returns:
+        An embedding client targeting the configured endpoint.
+
+    Raises:
+        ValueError: If the dimension is unresolvable or credentials are
+            missing (see :meth:`Settings.resolved_embedding_dimension`).
+    """
+    provider = settings.resolved_embedding_provider
+    base_url, api_key = resolve_embedding_endpoint(settings)
+    _ = settings.resolved_embedding_dimension  # fail fast, loudly
+
+    kwargs: dict[str, Any] = {
+        "api_key": api_key,
+        "base_url": base_url,
+        "model": settings.embedding_model,
+        "chunk_size": EMBEDDING_BATCH_SIZE,
+        "max_retries": 3,
+    }
+    if provider == "openai":
+        # text-embedding-3-* accept a server-side dimension override; only
+        # forward it when the operator chose one explicitly.
+        if settings.embedding_dimension is not None:
+            kwargs["dimensions"] = settings.embedding_dimension
+    else:
+        # Non-OpenAI servers (Ollama included) reject tiktoken token arrays
+        # on /v1/embeddings — send raw strings and skip the context-length
+        # precheck, which is OpenAI-specific anyway.
+        kwargs["check_embedding_ctx_length"] = False
+
+    return OpenAIEmbeddings(**kwargs)

--- a/agent/src/chatf1_agent/retrieval/vector_store.py
+++ b/agent/src/chatf1_agent/retrieval/vector_store.py
@@ -12,7 +12,6 @@ from typing import Any, cast
 
 import structlog
 from langchain_core.documents import Document
-from langchain_openai import OpenAIEmbeddings
 from langchain_pinecone import PineconeVectorStore
 from pinecone import Pinecone, ServerlessSpec
 from tenacity import (
@@ -24,6 +23,7 @@ from tenacity import (
 
 from chatf1_agent.caching import get_cache_manager
 from chatf1_agent.exceptions import VectorStoreError
+from chatf1_agent.providers import create_embeddings
 from chatf1_agent.settings import Settings
 
 logger = structlog.get_logger(__name__)
@@ -33,7 +33,6 @@ NAMESPACE_STATIC = "static_corpus"
 NAMESPACE_NEWS = "news"
 
 # Optimized batch sizes for different operations
-OPTIMAL_EMBEDDING_BATCH_SIZE = 100  # OpenAI embeddings API optimal batch size
 OPTIMAL_UPSERT_BATCH_SIZE = 100  # Pinecone upsert optimal batch size
 MAX_PARALLEL_BATCHES = 3  # Maximum parallel batch operations
 
@@ -69,7 +68,7 @@ class VectorStoreManager:
         Raises:
             VectorStoreError: If initialization fails
         """
-        config.require("pinecone_api_key", "openai_api_key")
+        config.require("pinecone_api_key")
         self.config = config
         self.logger = logger.bind(component="vector_store_manager")
 
@@ -84,16 +83,14 @@ class VectorStoreManager:
             raise VectorStoreError(f"Failed to initialize Pinecone client: {e}") from e
 
         try:
-            self.embeddings = OpenAIEmbeddings(
-                openai_api_key=config.openai_api_key,
-                model=config.openai_embedding_model,
-                chunk_size=OPTIMAL_EMBEDDING_BATCH_SIZE,
-                max_retries=3,
-            )
+            # Built through the provider factory: the embedding endpoint and
+            # dimension are settings-driven and validated eagerly there.
+            self.embeddings = create_embeddings(config)
             self.logger.info(
                 "embeddings_initialized",
-                model=config.openai_embedding_model,
-                chunk_size=OPTIMAL_EMBEDDING_BATCH_SIZE,
+                provider=config.resolved_embedding_provider,
+                model=config.embedding_model,
+                dimension=config.resolved_embedding_dimension,
             )
         except Exception as e:
             self.logger.error("embeddings_init_failed", error=str(e))
@@ -146,16 +143,17 @@ class VectorStoreManager:
             )
 
             if self.index_name not in existing_indexes:
+                dimension = self.config.resolved_embedding_dimension
                 self.logger.info(
                     "creating_index",
                     index_name=self.index_name,
-                    dimension=self.config.pinecone_dimension,
+                    dimension=dimension,
                 )
 
                 await asyncio.to_thread(
                     self.pc.create_index,
                     name=self.index_name,
-                    dimension=self.config.pinecone_dimension,
+                    dimension=dimension,
                     metric="cosine",
                     spec=ServerlessSpec(cloud="aws", region="us-east-1"),
                 )
@@ -166,6 +164,8 @@ class VectorStoreManager:
 
             await self._validate_index()
 
+        except VectorStoreError:
+            raise
         except Exception as e:
             self.logger.error(
                 "index_creation_failed",
@@ -175,10 +175,15 @@ class VectorStoreManager:
             raise VectorStoreError(f"Failed to ensure index exists: {e}") from e
 
     async def _validate_index(self) -> None:
-        """Validate index configuration matches expected settings.
+        """Validate that the live index matches the configured embeddings.
+
+        The dimension travels with the embedding provider — querying or
+        ingesting against a mismatched index silently produces garbage, so
+        this fails loudly with the remediation path instead.
 
         Raises:
-            VectorStoreError: If index configuration is invalid
+            VectorStoreError: If the live index dimension disagrees with
+                the configured embedding dimension.
         """
         try:
             index_description = await asyncio.to_thread(
@@ -186,13 +191,20 @@ class VectorStoreManager:
                 self.index_name,
             )
 
-            expected_dimension = self.config.pinecone_dimension
+            expected_dimension = self.config.resolved_embedding_dimension
             actual_dimension = index_description.dimension
 
             if actual_dimension != expected_dimension:
                 raise VectorStoreError(
-                    f"Index dimension mismatch: expected {expected_dimension}, "
-                    f"got {actual_dimension}"
+                    f"Embedding dimension mismatch: index "
+                    f"'{self.index_name}' is {actual_dimension}-dimensional, "
+                    f"but settings expect {expected_dimension} "
+                    f"({self.config.resolved_embedding_provider}/"
+                    f"{self.config.embedding_model}). Vectors from different "
+                    "embedding models are not interchangeable. Remediation: "
+                    "delete and recreate the index with `make reindex`, THEN "
+                    "re-ingest with `make ingest`. Never re-ingest into a "
+                    "mismatched index."
                 )
 
             self.logger.info(

--- a/agent/src/chatf1_agent/settings.py
+++ b/agent/src/chatf1_agent/settings.py
@@ -36,40 +36,92 @@ class Settings(BaseSettings):
         description="Static bearer token required on all /internal routes",
     )
 
-    # LLM configuration (gpt-4o-mini for both generation and analysis)
-    generation_model: str = Field(
+    # ── Model provider ──────────────────────────────────────────────────
+    # The agent speaks the OpenAI wire protocol to every provider; these
+    # settings only pick the endpoint and capabilities. Resolution rules
+    # live in chatf1_agent/providers.py; the reasoning lives in
+    # docs/adr/002-model-agnostic-providers.md.
+    llm_provider: Literal["openai", "ollama", "openai_compatible"] = Field(
+        default="openai",
+        description="Chat-model provider: openai, ollama, or any OpenAI-compatible endpoint",
+    )
+    llm_base_url: str | None = Field(
+        default=None,
+        description=(
+            "Chat endpoint override. None uses the provider default "
+            "(api.openai.com for openai, http://localhost:11434/v1 for ollama; "
+            "Ollama Cloud is https://ollama.com/v1). Required for openai_compatible."
+        ),
+    )
+    llm_api_key: str = Field(
+        default="",
+        description=(
+            "API key for non-OpenAI chat providers (e.g. Ollama Cloud). "
+            "Local servers that ignore auth get a dummy key automatically."
+        ),
+    )
+    llm_model: str = Field(
         default="gpt-4o-mini",
         description="Model used for answer generation",
     )
-    analysis_model: str = Field(
-        default="gpt-4o-mini",
-        description="Model used for structured query analysis",
+    llm_analysis_model: str = Field(
+        default="",
+        description="Model used for query analysis (empty = use llm_model)",
     )
-    openai_embedding_model: str = Field(
-        default="text-embedding-3-small",
-        description="OpenAI embedding model",
+    llm_supports_function_calling: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the chat model supports function-calling structured output. "
+            "None = provider default (true for openai, false otherwise). When "
+            "false, query analysis uses a prompted-JSON path instead."
+        ),
     )
-    openai_temperature: float = Field(
+    llm_temperature: float = Field(
         default=0.7,
         ge=0.0,
         le=2.0,
         description="Temperature for answer generation",
     )
-    openai_max_tokens: int = Field(
+    llm_max_tokens: int = Field(
         default=1000,
         ge=100,
         le=4000,
         description="Maximum tokens for LLM completion",
     )
 
+    # ── Embeddings (may target a different provider than the chat models) ─
+    embedding_provider: Literal["openai", "ollama", "openai_compatible"] | None = Field(
+        default=None,
+        description="Embedding provider (None = follow llm_provider)",
+    )
+    embedding_base_url: str | None = Field(
+        default=None,
+        description="Embedding endpoint override (None = provider default)",
+    )
+    embedding_api_key: str = Field(
+        default="",
+        description="API key for the embedding endpoint when it differs from the chat key",
+    )
+    embedding_model: str = Field(
+        default="text-embedding-3-small",
+        description="Embedding model name",
+    )
+    embedding_dimension: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Vector dimension produced by embedding_model. None is only valid "
+            "for OpenAI (1536, text-embedding-3-small); it MUST be explicit "
+            "for every other provider — e.g. nomic-embed-text=768, "
+            "mxbai-embed-large=1024. The Pinecone index is created with and "
+            "validated against this value."
+        ),
+    )
+
     # Pinecone
     pinecone_index_name: str = Field(
         default="f1-knowledge",
         description="Pinecone index name",
-    )
-    pinecone_dimension: int = Field(
-        default=1536,
-        description="Embedding dimension for the Pinecone index",
     )
 
     # Tavily
@@ -162,6 +214,54 @@ class Settings(BaseSettings):
                 return [item.strip() for item in v.split(",") if item.strip()]
             return [v]
         return v if v is not None else []
+
+    @property
+    def analysis_model(self) -> str:
+        """Model used for query analysis; defaults to the generation model."""
+        return self.llm_analysis_model or self.llm_model
+
+    @property
+    def supports_function_calling(self) -> bool:
+        """Whether the chat model can honor function-calling structured output.
+
+        Explicit ``llm_supports_function_calling`` wins; otherwise only the
+        OpenAI provider is assumed capable, and everything else gets the
+        prompted-JSON analysis path.
+        """
+        if self.llm_supports_function_calling is not None:
+            return self.llm_supports_function_calling
+        return self.llm_provider == "openai"
+
+    @property
+    def resolved_embedding_provider(self) -> str:
+        """Embedding provider, following llm_provider unless set explicitly."""
+        return self.embedding_provider or self.llm_provider
+
+    @property
+    def resolved_embedding_dimension(self) -> int:
+        """Embedding dimension the Pinecone index must match.
+
+        The dimension travels with the embedding model: vectors from
+        different models are not interchangeable, so a provider switch
+        without an explicit dimension is a configuration error, not
+        something to guess at.
+
+        Raises:
+            ValueError: If the provider is not OpenAI and no explicit
+                ``embedding_dimension`` was configured.
+        """
+        if self.embedding_dimension is not None:
+            return self.embedding_dimension
+        if self.resolved_embedding_provider == "openai":
+            return 1536  # text-embedding-3-small
+        raise ValueError(
+            "EMBEDDING_DIMENSION must be set explicitly when the embedding "
+            f"provider is '{self.resolved_embedding_provider}' — the index "
+            "dimension travels with the embedding model. Common values: "
+            "nomic-embed-text=768, mxbai-embed-large=1024, "
+            "text-embedding-3-small=1536. After changing it, rebuild the "
+            "index with `make reindex` BEFORE re-ingesting."
+        )
 
     @property
     def is_development(self) -> bool:

--- a/agent/tests/test_analysis_json_fallback.py
+++ b/agent/tests/test_analysis_json_fallback.py
@@ -1,0 +1,222 @@
+"""Tests for the prompted-JSON analysis path (non-function-calling models).
+
+When ``supports_function_calling`` is false (the default for Ollama), the
+analyze step prompts for strict JSON, retries exactly once with the
+validation error appended, and finally falls back to a safe route-to-both
+analysis. The NDJSON stream must stay clean in this mode too.
+"""
+
+import json
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import AIMessage, BaseMessage
+
+from chatf1_agent.caching import get_cache_manager
+from chatf1_agent.graph import F1AgentGraph, _extract_json, safe_default_analysis
+from chatf1_agent.server import ChatRequest, stream_chat_events
+from chatf1_agent.settings import Settings
+from chatf1_agent.state import AgentState
+
+VALID_ANALYSIS_JSON = json.dumps(
+    {
+        "intent": "current_info",
+        "confidence": 0.9,
+        "requires_search": True,
+        "requires_vector_search": False,
+        "entities": {"drivers": ["Max Verstappen"]},
+        "time_period": "2026 season",
+        "reasoning": "asks about a live result",
+    }
+)
+
+
+class FakeJSONLLM:
+    """Plain-`ainvoke` fake returning scripted replies in order."""
+
+    def __init__(self, replies: list[str]) -> None:
+        self.replies = list(replies)
+        self.calls: list[list[BaseMessage]] = []
+
+    async def ainvoke(self, messages: list[BaseMessage]) -> AIMessage:
+        self.calls.append(list(messages))
+        return AIMessage(content=self.replies.pop(0))
+
+
+@pytest.fixture(autouse=True)
+def clear_caches():
+    """Isolate the global TTL caches between tests."""
+    get_cache_manager().clear_all()
+    yield
+    get_cache_manager().clear_all()
+
+
+@pytest.fixture
+def make_json_graph(
+    mock_vector_store: Mock,
+    mock_tavily_client: Mock,
+    make_generation_llm: Any,
+):
+    """Factory for a graph running in JSON-analysis mode with fakes."""
+
+    def _make(replies: list[str]) -> tuple[F1AgentGraph, FakeJSONLLM]:
+        settings = Settings(_env_file=None, llm_provider="ollama")
+        assert settings.supports_function_calling is False
+
+        graph = F1AgentGraph(settings, mock_vector_store, mock_tavily_client)
+        fake = FakeJSONLLM(replies)
+        graph.analysis_llm = fake  # type: ignore[assignment]
+        graph.llm = make_generation_llm()
+        return graph, fake
+
+    return _make
+
+
+@pytest.mark.unit
+class TestJsonAnalysisPath:
+    """The happy path: the model emits valid JSON on the first try."""
+
+    async def test_valid_json_is_parsed(self, make_json_graph: Any):
+        """A valid JSON reply produces a normal analysis in one call."""
+        graph, fake = make_json_graph([VALID_ANALYSIS_JSON])
+
+        result = await graph.analyze_query_node(AgentState(query="Who leads?"))
+
+        assert len(fake.calls) == 1
+        assert result["intent"] == "current_info"
+        assert result["entities"] == {"drivers": ["Max Verstappen"]}
+        assert result["metadata"]["analysis_mode"] == "json"
+        assert result["metadata"]["requires_search"] is True
+        assert result["metadata"]["requires_vector_search"] is False
+        assert "analysis_fallback" not in result["metadata"]
+
+    async def test_markdown_fenced_json_is_tolerated(self, make_json_graph: Any):
+        """A fenced ```json reply still parses."""
+        graph, fake = make_json_graph(["```json\n" + VALID_ANALYSIS_JSON + "\n```"])
+
+        result = await graph.analyze_query_node(AgentState(query="Who leads?"))
+
+        assert len(fake.calls) == 1
+        assert result["intent"] == "current_info"
+
+    async def test_prompt_carries_schema_and_json_demand(self, make_json_graph: Any):
+        """The system prompt embeds the schema and forbids prose."""
+        graph, fake = make_json_graph([VALID_ANALYSIS_JSON])
+
+        await graph.analyze_query_node(AgentState(query="Who leads?"))
+
+        system_text = str(fake.calls[0][0].content)
+        assert "JSON Schema" in system_text
+        assert "requires_vector_search" in system_text  # schema made it in
+
+
+@pytest.mark.unit
+class TestJsonAnalysisRetry:
+    """One repair retry with the validation error appended."""
+
+    async def test_invalid_then_valid_json_retries_once(self, make_json_graph: Any):
+        """An invalid first reply triggers exactly one corrective call."""
+        graph, fake = make_json_graph(["{not json at all", VALID_ANALYSIS_JSON])
+
+        result = await graph.analyze_query_node(AgentState(query="Who leads?"))
+
+        assert len(fake.calls) == 2
+        assert result["intent"] == "current_info"
+        assert "analysis_fallback" not in result["metadata"]
+
+        # The retry prompt contains the bad reply and the parse error.
+        retry_messages = fake.calls[1]
+        assert any("{not json at all" in str(m.content) for m in retry_messages)
+        last = str(retry_messages[-1].content)
+        assert "Validation error" in last
+        assert "ONLY the corrected JSON object" in last
+
+    async def test_garbage_twice_falls_back_to_both(self, make_json_graph: Any):
+        """Two unusable replies yield the safe default: retrieve from both."""
+        graph, fake = make_json_graph(["complete garbage", "still garbage"])
+
+        result = await graph.analyze_query_node(AgentState(query="Who leads?"))
+
+        assert len(fake.calls) == 2  # exactly ONE retry, then give up
+        assert result["intent"] == "general"
+        assert result["metadata"]["requires_search"] is True
+        assert result["metadata"]["requires_vector_search"] is True
+        assert result["metadata"]["analysis_fallback"] is True
+
+    async def test_safe_default_routes_both(self):
+        """The safe default analysis always routes to both sources."""
+        analysis = safe_default_analysis("because tests")
+
+        assert analysis.intent == "general"
+        assert analysis.requires_search is True
+        assert analysis.requires_vector_search is True
+        assert analysis.confidence == 0.0
+
+
+@pytest.mark.unit
+class TestFunctionCallingPathUnchanged:
+    """OpenAI-class providers keep the structured-output path."""
+
+    async def test_default_settings_use_function_calling(
+        self,
+        test_settings: Settings,
+        mock_vector_store: Mock,
+        mock_tavily_client: Mock,
+        make_analysis: Any,
+    ):
+        """With the OpenAI default, analysis runs via with_structured_output."""
+        from .conftest import FakeAnalysisLLM
+
+        graph = F1AgentGraph(test_settings, mock_vector_store, mock_tavily_client)
+        graph.analysis_llm = FakeAnalysisLLM(make_analysis())  # type: ignore[assignment]
+
+        result = await graph.analyze_query_node(AgentState(query="Who leads?"))
+
+        assert result["metadata"]["analysis_mode"] == "function_calling"
+        assert "analysis_fallback" not in result["metadata"]
+
+
+@pytest.mark.unit
+class TestExtractJson:
+    """The lenient JSON extractor."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ('{"a": 1}', '{"a": 1}'),
+            ('```json\n{"a": 1}\n```', '{"a": 1}'),
+            ('Sure! Here you go: {"a": 1} hope that helps', '{"a": 1}'),
+            ("no braces here", "no braces here"),
+        ],
+    )
+    def test_extraction(self, text: str, expected: str):
+        """Fences and prose are stripped; brace-less text passes through."""
+        assert _extract_json(text) == expected
+
+
+@pytest.mark.unit
+class TestJsonModeStreamContract:
+    """The NDJSON stream stays clean when analysis runs in JSON mode."""
+
+    async def test_no_analysis_json_leaks_into_tokens(self, make_json_graph: Any):
+        """Tokens carry only generation output; analysis JSON never leaks."""
+        graph, _ = make_json_graph([VALID_ANALYSIS_JSON])
+        request = ChatRequest(
+            message="Who won the last race?", history=[], request_id="json-mode-1"
+        )
+
+        events = []
+        async for line in stream_chat_events(graph, request):
+            events.append(json.loads(line))
+
+        tokens = [e["text"] for e in events if e["event"] == "token"]
+        assert tokens, "generation must still stream tokens in JSON mode"
+        assert "".join(tokens) == "Max won the race."
+        for text in tokens:
+            assert "requires_search" not in text
+            assert "intent" not in text
+
+        complete = events[-1]
+        assert complete["event"] == "complete"
+        assert complete["content"] == "Max won the race."

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -17,10 +17,11 @@ def test_settings_loads_from_environment(test_settings: Settings):
 
 @pytest.mark.unit
 def test_settings_default_values(test_settings: Settings):
-    """Defaults match the v2 architecture: gpt-4o-mini everywhere."""
-    assert test_settings.generation_model == "gpt-4o-mini"
+    """Defaults match the v2 architecture: OpenAI gpt-4o-mini everywhere."""
+    assert test_settings.llm_provider == "openai"
+    assert test_settings.llm_model == "gpt-4o-mini"
     assert test_settings.analysis_model == "gpt-4o-mini"
-    assert test_settings.openai_embedding_model == "text-embedding-3-small"
+    assert test_settings.embedding_model == "text-embedding-3-small"
     assert test_settings.pinecone_index_name == "f1-knowledge"
     assert test_settings.app_name == "ChatFormula1"
     assert test_settings.log_level == "DEBUG"
@@ -30,7 +31,7 @@ def test_settings_default_values(test_settings: Settings):
 @pytest.mark.unit
 def test_settings_validation_constraints(test_settings: Settings):
     """Field constraints hold for the loaded settings."""
-    assert 0.0 <= test_settings.openai_temperature <= 2.0
+    assert 0.0 <= test_settings.llm_temperature <= 2.0
     assert 1 <= test_settings.tavily_max_results <= 10
     assert test_settings.max_conversation_history >= 1
     assert test_settings.vector_search_top_k >= 1
@@ -50,7 +51,7 @@ def test_settings_work_without_api_keys(monkeypatch: pytest.MonkeyPatch):
     settings = Settings(_env_file=None)
 
     assert settings.openai_api_key == ""
-    assert settings.generation_model == "gpt-4o-mini"
+    assert settings.llm_model == "gpt-4o-mini"
 
 
 @pytest.mark.unit

--- a/agent/tests/test_providers.py
+++ b/agent/tests/test_providers.py
@@ -1,0 +1,268 @@
+"""Tests for the model-agnostic provider factory.
+
+The factory matrix: provider (openai | ollama | openai_compatible) ×
+base URL (default | explicit) × credentials (real | dummy). All clients
+are constructed without network access, so every case runs keyless.
+"""
+
+from typing import Any
+
+import pytest
+
+from chatf1_agent.providers import (
+    DUMMY_API_KEY,
+    GENERATION_TAG,
+    OLLAMA_CLOUD_BASE_URL,
+    OLLAMA_LOCAL_BASE_URL,
+    create_analysis_llm,
+    create_embeddings,
+    create_generation_llm,
+)
+from chatf1_agent.settings import Settings
+
+
+def make_settings(**overrides: Any) -> Settings:
+    """Settings from the dummy test environment plus explicit overrides."""
+    return Settings(_env_file=None, **overrides)
+
+
+@pytest.mark.unit
+class TestChatFactoryMatrix:
+    """Provider × base_url × credentials for the chat models."""
+
+    def test_openai_defaults(self):
+        """OpenAI uses the library-default endpoint and the real key."""
+        llm = create_generation_llm(make_settings())
+
+        assert llm.openai_api_base is None
+        assert llm.openai_api_key is not None
+        assert llm.openai_api_key.get_secret_value() == "test-openai-key"
+        assert llm.model_name == "gpt-4o-mini"
+        assert llm.streaming is True
+        assert llm.tags == [GENERATION_TAG]
+
+    def test_openai_missing_key_fails_fast(self, monkeypatch: pytest.MonkeyPatch):
+        """The OpenAI provider refuses to construct without a key."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="openai_api_key"):
+            create_generation_llm(make_settings())
+
+    def test_ollama_local_defaults(self):
+        """Ollama defaults to the local /v1 endpoint with the dummy key."""
+        llm = create_generation_llm(
+            make_settings(llm_provider="ollama", llm_model="qwen3:8b")
+        )
+
+        assert llm.openai_api_base == OLLAMA_LOCAL_BASE_URL
+        assert llm.openai_api_key is not None
+        assert llm.openai_api_key.get_secret_value() == DUMMY_API_KEY
+        assert llm.model_name == "qwen3:8b"
+        assert llm.tags == [GENERATION_TAG]
+
+    def test_ollama_needs_no_openai_key(self, monkeypatch: pytest.MonkeyPatch):
+        """Local Ollama runs entirely keyless."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        llm = create_generation_llm(make_settings(llm_provider="ollama"))
+
+        assert llm.openai_api_key is not None
+        assert llm.openai_api_key.get_secret_value() == DUMMY_API_KEY
+
+    def test_ollama_cloud_base_url_and_key(self):
+        """Ollama Cloud is an explicit base URL plus a real key."""
+        llm = create_generation_llm(
+            make_settings(
+                llm_provider="ollama",
+                llm_base_url=OLLAMA_CLOUD_BASE_URL,
+                llm_api_key="ollama-cloud-key",
+                llm_model="gpt-oss:120b",
+            )
+        )
+
+        assert llm.openai_api_base == OLLAMA_CLOUD_BASE_URL
+        assert llm.openai_api_key is not None
+        assert llm.openai_api_key.get_secret_value() == "ollama-cloud-key"
+
+    def test_openai_compatible_requires_base_url(self):
+        """A generic compatible endpoint has no default to guess."""
+        with pytest.raises(ValueError, match="llm_base_url"):
+            create_generation_llm(make_settings(llm_provider="openai_compatible"))
+
+    def test_openai_compatible_with_base_url(self):
+        """An explicit compatible endpoint constructs with the dummy key."""
+        llm = create_generation_llm(
+            make_settings(
+                llm_provider="openai_compatible",
+                llm_base_url="http://vllm.internal:8000/v1",
+                llm_model="meta-llama/Llama-3.1-8B-Instruct",
+            )
+        )
+
+        assert llm.openai_api_base == "http://vllm.internal:8000/v1"
+        assert llm.openai_api_key is not None
+        assert llm.openai_api_key.get_secret_value() == DUMMY_API_KEY
+
+    def test_settings_load_from_environment(self, monkeypatch: pytest.MonkeyPatch):
+        """Provider selection is reachable purely through env vars."""
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("LLM_MODEL", "llama3.2:3b")
+
+        llm = create_generation_llm(Settings(_env_file=None))
+
+        assert llm.openai_api_base == OLLAMA_LOCAL_BASE_URL
+        assert llm.model_name == "llama3.2:3b"
+
+
+@pytest.mark.unit
+class TestAnalysisModel:
+    """The analysis model shares the chat endpoint but stays untagged."""
+
+    def test_defaults_to_generation_model(self):
+        """With no override, analysis uses the generation model at temp 0."""
+        llm = create_analysis_llm(make_settings())
+
+        assert llm.model_name == "gpt-4o-mini"
+        assert llm.temperature == 0.0
+        assert not llm.tags or GENERATION_TAG not in llm.tags
+
+    def test_explicit_analysis_model(self):
+        """llm_analysis_model overrides the generation model."""
+        llm = create_analysis_llm(
+            make_settings(llm_model="gpt-4o", llm_analysis_model="gpt-4o-mini")
+        )
+
+        assert llm.model_name == "gpt-4o-mini"
+
+    def test_analysis_follows_provider_endpoint(self):
+        """The analysis model targets the same provider endpoint."""
+        llm = create_analysis_llm(make_settings(llm_provider="ollama"))
+
+        assert llm.openai_api_base == OLLAMA_LOCAL_BASE_URL
+
+
+@pytest.mark.unit
+class TestFunctionCallingCapability:
+    """Capability flag defaults per provider, overridable either way."""
+
+    @pytest.mark.parametrize(
+        ("provider", "override", "expected"),
+        [
+            ("openai", None, True),
+            ("ollama", None, False),
+            ("openai_compatible", None, False),
+            ("ollama", True, True),
+            ("openai", False, False),
+        ],
+    )
+    def test_capability_matrix(
+        self, provider: str, override: bool | None, expected: bool
+    ):
+        """supports_function_calling: provider default unless overridden."""
+        settings = make_settings(
+            llm_provider=provider,
+            llm_supports_function_calling=override,
+        )
+
+        assert settings.supports_function_calling is expected
+
+    def test_override_via_environment(self, monkeypatch: pytest.MonkeyPatch):
+        """The override is reachable through the environment."""
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("LLM_SUPPORTS_FUNCTION_CALLING", "true")
+
+        assert Settings(_env_file=None).supports_function_calling is True
+
+
+@pytest.mark.unit
+class TestEmbeddingFactory:
+    """Embedding endpoint, model, and dimension resolution."""
+
+    def test_openai_defaults(self):
+        """OpenAI embeddings: default endpoint, 1536 implied, ctx check on."""
+        settings = make_settings()
+        embeddings = create_embeddings(settings)
+
+        assert embeddings.openai_api_base is None
+        assert embeddings.model == "text-embedding-3-small"
+        assert embeddings.check_embedding_ctx_length is True
+        assert embeddings.dimensions is None
+        assert settings.resolved_embedding_dimension == 1536
+
+    def test_openai_explicit_dimension_is_forwarded(self):
+        """An explicit dimension reaches the OpenAI client (3-small/large)."""
+        embeddings = create_embeddings(make_settings(embedding_dimension=256))
+
+        assert embeddings.dimensions == 256
+
+    def test_embeddings_follow_chat_provider(self):
+        """Without embedding_provider, embeddings inherit the chat endpoint."""
+        embeddings = create_embeddings(
+            make_settings(
+                llm_provider="ollama",
+                embedding_model="nomic-embed-text",
+                embedding_dimension=768,
+            )
+        )
+
+        assert embeddings.openai_api_base == OLLAMA_LOCAL_BASE_URL
+        assert embeddings.openai_api_key is not None
+        assert embeddings.openai_api_key.get_secret_value() == DUMMY_API_KEY
+        assert embeddings.check_embedding_ctx_length is False
+
+    def test_embeddings_inherit_chat_base_url_and_key(self):
+        """Inherited provider also inherits the chat base URL and key."""
+        embeddings = create_embeddings(
+            make_settings(
+                llm_provider="ollama",
+                llm_base_url=OLLAMA_CLOUD_BASE_URL,
+                llm_api_key="ollama-cloud-key",
+                embedding_model="nomic-embed-text",
+                embedding_dimension=768,
+            )
+        )
+
+        assert embeddings.openai_api_base == OLLAMA_CLOUD_BASE_URL
+        assert embeddings.openai_api_key is not None
+        assert embeddings.openai_api_key.get_secret_value() == "ollama-cloud-key"
+
+    def test_split_providers_do_not_leak_endpoints(self):
+        """An explicit embedding provider ignores the chat endpoint."""
+        embeddings = create_embeddings(
+            make_settings(
+                llm_provider="openai_compatible",
+                llm_base_url="http://vllm.internal:8000/v1",
+                embedding_provider="ollama",
+                embedding_model="mxbai-embed-large",
+                embedding_dimension=1024,
+            )
+        )
+
+        assert embeddings.openai_api_base == OLLAMA_LOCAL_BASE_URL
+        assert embeddings.model == "mxbai-embed-large"
+
+    def test_missing_dimension_fails_loudly(self):
+        """Non-OpenAI embeddings without a dimension are a config error."""
+        settings = make_settings(
+            llm_provider="ollama",
+            embedding_model="nomic-embed-text",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            create_embeddings(settings)
+
+        message = str(exc_info.value)
+        assert "EMBEDDING_DIMENSION" in message
+        assert "768" in message
+        assert "make reindex" in message
+
+    def test_embedding_dimension_via_environment(self, monkeypatch: pytest.MonkeyPatch):
+        """The dimension is reachable through the environment."""
+        monkeypatch.setenv("LLM_PROVIDER", "ollama")
+        monkeypatch.setenv("EMBEDDING_MODEL", "nomic-embed-text")
+        monkeypatch.setenv("EMBEDDING_DIMENSION", "768")
+
+        settings = Settings(_env_file=None)
+
+        assert settings.resolved_embedding_dimension == 768
+        assert create_embeddings(settings).check_embedding_ctx_length is False

--- a/agent/tests/test_vector_store_integration.py
+++ b/agent/tests/test_vector_store_integration.py
@@ -69,6 +69,50 @@ def test_manager_requires_credentials(monkeypatch: pytest.MonkeyPatch):
         VectorStoreManager(settings)
 
 
+@pytest.mark.unit
+class TestDimensionValidation:
+    """The live index dimension must match the configured embeddings."""
+
+    async def test_mismatch_fails_loudly_with_remediation(
+        self, test_settings: Settings, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A mismatched index raises with the `make reindex` remediation."""
+        from types import SimpleNamespace
+
+        from chatf1_agent.exceptions import VectorStoreError
+
+        manager = VectorStoreManager(test_settings)
+        monkeypatch.setattr(
+            manager.pc,
+            "describe_index",
+            lambda name: SimpleNamespace(dimension=768, metric="cosine"),
+        )
+
+        with pytest.raises(VectorStoreError) as exc_info:
+            await manager._validate_index()
+
+        message = str(exc_info.value)
+        assert "768" in message
+        assert "1536" in message
+        assert "make reindex" in message
+        assert test_settings.embedding_model in message
+
+    async def test_matching_dimension_passes(
+        self, test_settings: Settings, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A matching index validates without error."""
+        from types import SimpleNamespace
+
+        manager = VectorStoreManager(test_settings)
+        monkeypatch.setattr(
+            manager.pc,
+            "describe_index",
+            lambda name: SimpleNamespace(dimension=1536, metric="cosine"),
+        )
+
+        await manager._validate_index()
+
+
 @pytest.mark.integration
 @pytest.mark.asyncio
 class TestVectorStoreIntegration:
@@ -90,7 +134,7 @@ class TestVectorStoreIntegration:
         health = await vector_store.health_check()
 
         assert health["status"] == "healthy"
-        assert health["dimension"] == vector_store.config.pinecone_dimension
+        assert health["dimension"] == vector_store.config.resolved_embedding_dimension
 
     async def test_add_and_search_documents(self, vector_store: VectorStoreManager):
         """Documents upsert deterministically and are searchable."""

--- a/docs/adr/002-model-agnostic-providers.md
+++ b/docs/adr/002-model-agnostic-providers.md
@@ -1,0 +1,112 @@
+# ADR-002: Model-agnostic providers (OpenAI + Ollama first-class)
+
+- **Status:** Accepted
+- **Date:** 2026-06-10
+- **Owner direction:** "go Ollama, and make the whole app model-agnostic."
+
+## Context
+
+The agent was OpenAI-only: `ChatOpenAI` and `OpenAIEmbeddings` were
+constructed with implicit OpenAI assumptions (endpoint, function calling,
+1536-dim embeddings) in two different modules. That coupling had three
+costs:
+
+1. **Vendor lock-in** — no way to run the app on local or self-hosted
+   models, and no negotiating position on inference cost.
+2. **Hidden capability assumptions** — the query-analysis step used
+   `with_structured_output`, which compiles to OpenAI function calling.
+   Most local models don't implement tool calling reliably; the failure
+   mode is silent garbage, not an error.
+3. **A buried embedding constant** — the Pinecone index dimension (1536)
+   was an OpenAI fact pretending to be an application fact. Switching
+   embedding models without realizing this corrupts retrieval quietly:
+   queries embed in one space, documents in another.
+
+Meanwhile, the local-model ecosystem converged on a de facto standard:
+Ollama, vLLM, LM Studio, and OpenRouter all serve the **OpenAI wire
+protocol** (Ollama at `/v1`, Ollama Cloud at `https://ollama.com/v1`).
+
+## Decision
+
+### 1. One factory, one wire protocol
+
+All model construction goes through `agent/src/chatf1_agent/providers.py`:
+`create_generation_llm`, `create_analysis_llm`, `create_embeddings`. The
+factory always builds `langchain-openai` clients (exact-pinned at 1.1.0)
+and varies only `base_url`, `api_key`, and capability flags from settings:
+
+- `llm_provider`: `openai` | `ollama` | `openai_compatible`
+- `llm_base_url`: `None` → provider default (OpenAI's API, or
+  `http://localhost:11434/v1` for Ollama); **required** for
+  `openai_compatible` because there is no endpoint to guess
+- Ollama gets a dummy `api_key` (`"ollama"`) when none is set — the
+  OpenAI client library demands one, local servers ignore it
+
+We deliberately did **not** add `langchain-ollama` (a second dependency
+and code path when `/v1` suffices), a LiteLLM proxy (extra infra for a
+single service), or a provider plugin registry (YAGNI — the protocol is
+the abstraction).
+
+The factory is also where the streaming contract is enforced: only the
+generation model carries the `["generation"]` tag that the NDJSON server
+filters on. Constructing a model outside the factory would bypass that.
+
+### 2. Capabilities are configuration: the JSON fallback
+
+`llm_supports_function_calling` (default: true for `openai`, false
+otherwise) tells the graph which structured-output strategy to use:
+
+- **true** — unchanged `with_structured_output` (function calling).
+- **false** — prompt-and-parse: the analysis prompt embeds the
+  `QueryAnalysis` JSON Schema and demands a bare JSON object, parsed with
+  Pydantic `model_validate_json`. One repair retry with the validation
+  error appended; if that fails too, a safe default routes retrieval to
+  **both** sources rather than failing the user's turn.
+
+We chose prompt-and-parse over the OpenAI `response_format=json_object`
+flag because support for it varies across compatible servers; a prompt
+plus a strict parser works everywhere. Both paths keep the analysis model
+untagged, so analysis output can never leak into the user-visible token
+stream — the frozen NDJSON contract tests pass unchanged.
+
+### 3. The embedding dimension travels with the provider
+
+`embedding_provider` / `embedding_model` / `embedding_dimension` are
+independent of the chat settings (chat on Ollama Cloud + embeddings on
+OpenAI is a supported, sensible split). The rules:
+
+- `embedding_dimension` is implied (1536) **only** for OpenAI's
+  `text-embedding-3-small`. For every other provider it MUST be explicit
+  (`nomic-embed-text` = 768, `mxbai-embed-large` = 1024) — construction
+  fails otherwise.
+- The vector store validates the **live** Pinecone index dimension
+  against settings at startup and fails loudly with the remediation:
+  delete + recreate via `make reindex`, **then** re-ingest. Today the
+  index is empty, so a provider switch is free; after launch it costs a
+  full re-ingestion, which is exactly why the check is loud.
+
+## Why Ollama
+
+- **Local:** zero API cost, no data egress, offline dev, and the test of
+  honesty for "model-agnostic" claims — if it runs on a laptop model, the
+  seam is real. Tradeoffs: cold model loads (seconds to tens of seconds
+  on first request), small models analyze queries less reliably (hence
+  the JSON fallback's safe default), and embedding quality below
+  `text-embedding-3-small` for retrieval.
+- **Cloud:** big open models (e.g. `gpt-oss:120b`) without local VRAM,
+  same wire protocol, just `LLM_BASE_URL=https://ollama.com/v1` plus an
+  API key. Tradeoffs: free-tier rate/usage limits, chat-only catalog (run
+  embeddings locally or keep OpenAI), and another vendor — agnostic, not
+  vendor-free.
+
+## Consequences
+
+- Switching providers is a 4-line env change (see `agent/README.md`);
+  no code changes, and the streaming contract is provider-invariant.
+- Changing the **embedding** provider/model is never just env: it
+  requires `make reindex` + re-ingest, and the system enforces that
+  instead of degrading silently.
+- The test suite still runs with zero real keys; the factory matrix,
+  JSON fallback, and dimension validation are all covered offline.
+- We own a small JSON-repair loop instead of depending on every
+  provider's structured-output implementation.


### PR DESCRIPTION
## Summary

Implements the owner direction (2026-06-10): **go Ollama, make the whole app model-agnostic.** The Python agent now constructs every LLM and embedding client through a settings-driven provider factory; OpenAI and Ollama are first-class, any OpenAI-compatible endpoint works.

### Provider factory (`chatf1_agent/providers.py`)
- `llm_provider` = `openai | ollama | openai_compatible`; `base_url` resolution per provider (Ollama local `:11434/v1` default, Ollama Cloud, custom); separate `llm_api_key`/`embedding_api_key` so an Ollama Cloud key never masquerades as `OPENAI_API_KEY`; generation/analysis/embedding clients all factory-built (verified against langchain-openai 1.1.0 pins)
- Generation tag filtering (the no-analysis-JSON-in-stream guarantee) preserved in every path

### Structured-output fallback
Non-function-calling models (most Ollama models) get a prompted-JSON analysis path: schema embedded in prompt → `model_validate_json` → ONE repair retry with the validation error appended → `safe_default_analysis` routing "both". Chosen over `response_format=json_object` for cross-server compatibility (ADR-002).

### Embedding dimension travels with the provider
- Implicit 1536 only for OpenAI; any other provider must set `EMBEDDING_DIMENSION` explicitly (768 nomic-embed-text / 1024 mxbai-embed-large documented) — loud `ValueError` otherwise
- Vector store validates the live index dimension against settings and fails with the exact remediation: `make reindex` (new, implements the ARCHITECTURE.md command) then re-ingest — **free right now because the index is empty; never after**
- `f1-ingest check-config` prints provider/model/dimension/index match

### Docs
ADR-002, agent README provider section with honest Ollama local/Cloud tradeoffs, `.env.example` blocks for all three setups. Switching to Ollama locally is four env lines.

## Test plan
- **175 passed, 3 skipped** (was 137; +38 provider/fallback/dimension tests), run with zero API keys
- **NDJSON contract: byte-identical** — `git diff` on contract tests and `docs/STREAMING_PROTOCOL.md` is empty
- ruff / black / mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-provider LLM support: Configure OpenAI (default), Ollama (local/cloud), or any OpenAI-compatible endpoint via environment variables.
  * New `make reindex` command to rebuild and recreate the Pinecone vector index.

* **Documentation**
  * Updated configuration examples and README with provider setup guidance and embedding model details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->